### PR TITLE
Feat: add mistral support, refactor completion args method

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ pip install .
 - Groq
 - Huggingface
 - Minimax
+- Mistral
 - ModelScope
 - Ollama
 - Openai
@@ -301,6 +302,14 @@ MODEL=deepseek-chat
 PROVIDER=openrouter
 API_KEY=
 MODEL=deepseek/deepseek-chat-v3-0324
+```
+
+#### Mistral
+
+```ini
+PROVIDER=mistral
+API_KEY=
+MODEL=codestral-latest
 ```
 
 #### Gemini

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ all = [
     "cohere>=5.15.0",
     "google-genai>=1.20.0",
     "huggingface-hub>=0.33.0",
+    "mistralai>=1.8.2",
 ]
 doubao = ["volcengine-python-sdk>=3.0.15"]
 ollama = ["ollama>=0.5.1"]
@@ -115,6 +116,7 @@ dev = [
     "pytest-cov>=6.1.1",
     "ruff>=0.11.2",
     "tox>=4.27.0",
+    "tox-uv>=1.26.1",
 ]
 
 [tool.isort]

--- a/tests/llms/test_mistral_provider.py
+++ b/tests/llms/test_mistral_provider.py
@@ -1,0 +1,592 @@
+# type: ignore
+from unittest.mock import MagicMock, patch
+
+import pytest
+from mistralai.models import ChatCompletionResponse
+from mistralai.utils.eventstreaming import EventStream
+
+from yaicli.exceptions import MCPToolsError
+from yaicli.llms.providers.mistral_provider import MistralProvider
+from yaicli.schemas import ChatMessage, ToolCall
+
+
+class TestMistralProvider:
+    """Tests for Mistral provider implementation"""
+
+    @pytest.fixture
+    def mock_config(self):
+        """Fixture to create a mock configuration for tests"""
+        return {
+            "API_KEY": "fake_api_key",
+            "BASE_URL": None,
+            "SERVER": None,
+            "MODEL": "mistral-large-latest",
+            "TEMPERATURE": 0.7,
+            "TOP_P": 0.9,
+            "MAX_TOKENS": 1024,
+            "TIMEOUT": 30,
+            "EXTRA_HEADERS": None,
+            "STREAM": True,
+            "ENABLE_FUNCTIONS": True,
+            "ENABLE_MCP": False,
+        }
+
+    @pytest.fixture
+    def mock_mistral_client(self):
+        """Create a mocked Mistral client"""
+        client_mock = MagicMock()
+        chat_mock = MagicMock()
+        client_mock.chat = chat_mock
+        return client_mock
+
+    def test_init(self, mock_config):
+        """Test initialization of MistralProvider"""
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                provider = MistralProvider(config=mock_config)
+
+                # Check initialization parameters
+                assert provider.config == mock_config
+                assert provider.enable_functions == mock_config["ENABLE_FUNCTIONS"]
+                assert provider.enable_mcp == mock_config["ENABLE_MCP"]
+
+    def test_get_client_params(self, mock_config):
+        """Test get_client_params method returns the expected parameters"""
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                provider = MistralProvider(config=mock_config)
+                params = provider.get_client_params()
+
+                assert params == {
+                    "api_key": mock_config["API_KEY"],
+                    "timeout_ms": mock_config["TIMEOUT"] * 1000,
+                }
+
+    def test_get_client_params_with_base_url(self, mock_config):
+        """Test get_client_params with custom base URL"""
+        mock_config["BASE_URL"] = "https://custom-api.mistral.ai/v1"
+        mock_config["SERVER"] = "custom-server"
+
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                provider = MistralProvider(config=mock_config)
+                params = provider.get_client_params()
+
+                assert params == {
+                    "api_key": mock_config["API_KEY"],
+                    "timeout_ms": mock_config["TIMEOUT"] * 1000,
+                    "server_url": mock_config["BASE_URL"],
+                    "server": mock_config["SERVER"],
+                }
+
+    def test_get_completion_params(self, mock_config):
+        """Test get_completion_params method returns the expected parameters"""
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                provider = MistralProvider(config=mock_config)
+                params = provider.get_completion_params()
+
+                # Verify basic parameters
+                assert params["model"] == mock_config["MODEL"]
+                assert params["temperature"] == mock_config["TEMPERATURE"]
+                assert params["top_p"] == mock_config["TOP_P"]
+                assert params["max_tokens"] == mock_config["MAX_TOKENS"]
+                assert params["stream"] == mock_config["STREAM"]
+                assert params["http_headers"] == {
+                    "X-Title": provider.APP_NAME,
+                    "HTTP_Referer": provider.APP_REFERER,
+                }
+
+    def test_get_completion_params_with_extra_headers(self, mock_config):
+        """Test get_completion_params with extra headers"""
+        mock_config["EXTRA_HEADERS"] = {"X-Custom": "test"}
+
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                provider = MistralProvider(config=mock_config)
+                params = provider.get_completion_params()
+
+                # Verify headers are combined correctly
+                assert "X-Custom" in params["http_headers"]
+                assert params["http_headers"]["X-Custom"] == "test"
+                assert "X-Title" in params["http_headers"]
+
+    @patch("yaicli.llms.providers.mistral_provider.get_openai_schemas")
+    def test_get_completion_params_with_functions(self, mock_get_schemas, mock_config):
+        """Test get_completion_params with functions enabled"""
+        mock_get_schemas.return_value = [{"type": "function", "function": {"name": "test_func"}}]
+
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                provider = MistralProvider(config=mock_config)
+                params = provider.get_completion_params()
+
+                # Verify functions are included
+                assert "tools" in params
+                assert params["tool_choice"] == "auto"
+                assert params["parallel_tool_calls"] is False
+                assert len(params["tools"]) == 1
+
+    @patch("yaicli.llms.providers.mistral_provider.get_openai_schemas")
+    @patch("yaicli.llms.providers.mistral_provider.get_openai_mcp_tools")
+    def test_get_completion_params_with_mcp(self, mock_get_mcp_tools, mock_get_schemas, mock_config):
+        """Test get_completion_params with MCP tools enabled"""
+        mock_config["ENABLE_MCP"] = True
+        
+        mock_get_schemas.return_value = [{"type": "function", "function": {"name": "test_func"}}]
+        mock_get_mcp_tools.return_value = [{"type": "function", "function": {"name": "mcp_func"}}]
+
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                provider = MistralProvider(config=mock_config)
+                params = provider.get_completion_params()
+
+                # Verify both function types are included
+                assert "tools" in params
+                assert len(params["tools"]) == 2
+
+    @patch("yaicli.llms.providers.mistral_provider.get_openai_schemas")
+    @patch("yaicli.llms.providers.mistral_provider.get_openai_mcp_tools")
+    def test_get_completion_params_mcp_error(self, mock_get_mcp_tools, mock_get_schemas, mock_config):
+        """Test error handling when MCP tools raise an error"""
+        mock_config["ENABLE_MCP"] = True
+        mock_get_schemas.return_value = [{"type": "function", "function": {"name": "regular_func"}}]
+        mock_get_mcp_tools.side_effect = MCPToolsError("Error loading MCP tools")
+
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                provider = MistralProvider(config=mock_config)
+                params = provider.get_completion_params()
+
+                # Should still return valid parameters, just without MCP tools
+                assert "tools" in params
+                assert len(params["tools"]) == 1
+                assert params["tools"][0]["function"]["name"] == "regular_func"
+
+    def test_handle_normal_response(self, mock_config):
+        """Test _handle_normal_response method correctly processes a response"""
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                provider = MistralProvider(config=mock_config)
+
+                # Create a mock response
+                mock_response = MagicMock(spec=ChatCompletionResponse)
+                mock_choice = MagicMock()
+                mock_message = MagicMock()
+                mock_message.content = "Test response"
+                mock_choice.message = mock_message
+                mock_choice.finish_reason = "stop"
+                mock_response.choices = [mock_choice]
+
+                # Process the response
+                responses = list(provider._handle_normal_response(mock_response))
+
+                # Verify response handling
+                assert len(responses) == 1
+                assert responses[0].content == "Test response"
+                assert responses[0].finish_reason == "stop"
+                assert responses[0].tool_call is None
+
+    def test_handle_normal_response_with_tool_calls(self, mock_config):
+        """Test _handle_normal_response with tool calls"""
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                provider = MistralProvider(config=mock_config)
+
+                # Create a mock response with tool call
+                mock_response = MagicMock(spec=ChatCompletionResponse)
+                mock_choice = MagicMock()
+                mock_message = MagicMock()
+                mock_message.content = "Let me check something"
+                
+                # Create a mock tool call
+                mock_tool_call = MagicMock()
+                mock_tool_call.id = "call_123"
+                mock_function = MagicMock()
+                mock_function.name = "test_function"
+                mock_function.arguments = '{"param": "value"}'
+                mock_tool_call.function = mock_function
+                mock_message.tool_calls = [mock_tool_call]
+                
+                mock_choice.message = mock_message
+                mock_choice.finish_reason = "tool_calls"
+                mock_response.choices = [mock_choice]
+
+                # Process the response
+                responses = list(provider._handle_normal_response(mock_response))
+
+                # Verify response handling
+                assert len(responses) == 1
+                assert responses[0].content == "Let me check something"
+                assert responses[0].finish_reason == "tool_calls"
+                assert responses[0].tool_call is not None
+                assert responses[0].tool_call.name == "test_function"
+                assert responses[0].tool_call.arguments == '{"param": "value"}'
+
+    def test_process_tool_call_chunk(self, mock_config):
+        """Test _process_tool_call_chunk method correctly processes tool call data"""
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                provider = MistralProvider(config=mock_config)
+
+                # Create mock tool calls
+                mock_tool_call = MagicMock()
+                mock_function = MagicMock()
+                mock_function.name = "weather_function"
+                mock_function.arguments = '{"location"'  # Partial JSON
+                mock_tool_call.function = mock_function
+                mock_tool_call.id = "call_123"
+
+                # Process first chunk
+                result = provider._process_tool_call_chunk([mock_tool_call])
+                
+                assert result.id == "call_123"
+                assert result.name == "weather_function"
+                assert result.arguments == '{"location"'
+
+                # Process second chunk with continuation of arguments
+                mock_tool_call2 = MagicMock()
+                mock_function2 = MagicMock()
+                mock_function2.arguments = ': "New York"}'
+                mock_tool_call2.function = mock_function2
+
+                # Continue processing with existing tool call
+                result = provider._process_tool_call_chunk([mock_tool_call2], result)
+                
+                assert result.arguments == '{"location": "New York"}'
+
+    def test_get_content_from_delta_content_string(self, mock_config):
+        """Test get_content_from_delta_content with string input"""
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                provider = MistralProvider(config=mock_config)
+                
+                content = provider.get_content_from_delta_content("Hello world")
+                assert content == "Hello world"
+
+    @patch("yaicli.llms.providers.mistral_provider.MistralProvider.extract_contents_list")
+    def test_get_content_from_delta_content_list(self, mock_extract_contents, mock_config):
+        """Test get_content_from_delta_content with ContentChunk list"""
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                provider = MistralProvider(config=mock_config)
+                
+                # Mock the extract_contents_list method return value
+                mock_extract_contents.return_value = "Processed content"
+                
+                # Create a list that would be passed as ContentChunk list
+                chunks = []
+                
+                # Call the method with our list
+                content = provider.get_content_from_delta_content(chunks)
+                
+                # Check if extract_contents_list was called with our list
+                mock_extract_contents.assert_called_once_with(chunks)
+                assert content == "Processed content"
+
+    def test_extract_contents_list(self, mock_config):
+        """Test extract_contents_list method"""
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                provider = MistralProvider(config=mock_config)
+                
+                # Create mocks for different content chunk types
+                text_chunk = MagicMock()
+                text_chunk.type = "text"
+                text_chunk.text = "Hello "
+                
+                image_chunk = MagicMock()
+                image_chunk.type = "image_url"
+                image_chunk.image_url = "http://example.com/image.png"
+                
+                image_chunk_obj = MagicMock()
+                image_chunk_obj.type = "image_url"
+                image_chunk_obj.image_url = MagicMock()
+                image_chunk_obj.image_url.url = "http://example.com/image2.png"
+                
+                document_chunk = MagicMock()
+                document_chunk.type = "document_url"
+                document_chunk.document_url = "http://example.com/doc.pdf"
+                document_chunk.document_name = "Document"
+                
+                reference_chunk = MagicMock()
+                reference_chunk.type = "reference"
+                reference_chunk.reference_ids = ["ref1", "ref2"]
+                
+                # Call the method with our mocked chunks
+                chunks = [text_chunk, image_chunk, image_chunk_obj, document_chunk, reference_chunk]
+                content = provider.extract_contents_list(chunks)
+                
+                # Verify output contains expected content from each chunk type
+                assert "Hello " in content
+                assert "http://example.com/image.png" in content
+                assert "http://example.com/image2.png" in content
+                assert "[Document](http://example.com/doc.pdf)" in content
+                assert "Reference IDs" in content
+                assert "ref1" in content
+                assert "ref2" in content
+
+    def test_detect_tool_role(self, mock_config):
+        """Test detect_tool_role returns the expected role"""
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                provider = MistralProvider(config=mock_config)
+                assert provider.detect_tool_role() == "tool"
+    
+    def test_completion_non_streaming(self, mock_config):
+        """Test completion method with non-streaming response"""
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                # Set up mocks
+                provider = MistralProvider(config=mock_config)
+                
+                # Mock _convert_messages method
+                provider._convert_messages = MagicMock(return_value=[{"role": "user", "content": "Hello"}])
+                
+                # Mock client.chat.complete method
+                mock_response = MagicMock(spec=ChatCompletionResponse)
+                mock_choice = MagicMock()
+                mock_message = MagicMock()
+                mock_message.content = "Test response"
+                mock_choice.message = mock_message
+                mock_choice.finish_reason = "stop"
+                mock_response.choices = [mock_choice]
+                
+                provider.client.chat.complete = MagicMock(return_value=mock_response)
+                
+                # Create test messages
+                messages = [ChatMessage(role="user", content="Hello")]
+                
+                # Call the completion method with streaming=False
+                responses = list(provider.completion(messages, stream=False))
+                
+                # Verify _convert_messages was called
+                provider._convert_messages.assert_called_once_with(messages)
+                
+                # Verify complete method was called with correct parameters
+                provider.client.chat.complete.assert_called_once()
+                
+                # Verify response
+                assert len(responses) == 1
+                assert responses[0].content == "Test response"
+                assert responses[0].finish_reason == "stop"
+    
+    def test_completion_streaming(self, mock_config):
+        """Test completion method with streaming response"""
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                # Set up mocks
+                provider = MistralProvider(config=mock_config)
+                
+                # Mock _convert_messages method
+                provider._convert_messages = MagicMock(return_value=[{"role": "user", "content": "Hello"}])
+                
+                # Create mock for stream response
+                mock_event_stream = MagicMock(spec=EventStream)
+                
+                # Create mock for stream chunks
+                mock_chunk1 = MagicMock()
+                mock_choice1 = MagicMock()
+                mock_delta1 = MagicMock()
+                mock_delta1.content = "Hello"
+                mock_choice1.delta = mock_delta1
+                mock_choice1.finish_reason = None
+                mock_chunk1.data.choices = [mock_choice1]
+                
+                mock_chunk2 = MagicMock()
+                mock_choice2 = MagicMock()
+                mock_delta2 = MagicMock()
+                mock_delta2.content = " world"
+                mock_choice2.delta = mock_delta2
+                mock_choice2.finish_reason = "stop"
+                mock_chunk2.data.choices = [mock_choice2]
+                
+                # Set up the mock event stream to yield our chunks
+                mock_event_stream.__iter__ = MagicMock(return_value=iter([mock_chunk1, mock_chunk2]))
+                
+                # Mock client.chat.stream method
+                provider.client.chat.stream = MagicMock(return_value=mock_event_stream)
+                
+                # Create test messages
+                messages = [ChatMessage(role="user", content="Hello")]
+                
+                # Call the completion method with streaming=True
+                responses = list(provider.completion(messages, stream=True))
+                
+                # Verify _convert_messages was called
+                provider._convert_messages.assert_called_once_with(messages)
+                
+                # Verify stream method was called with correct parameters
+                provider.client.chat.stream.assert_called_once()
+                
+                # Verify responses
+                assert len(responses) == 2
+                assert responses[0].content == "Hello"
+                assert responses[0].finish_reason is None
+                assert responses[1].content == " world"
+                assert responses[1].finish_reason == "stop"
+    
+    def test_handle_stream_response_with_tool_calls(self, mock_config):
+        """Test _handle_stream_response with tool calls"""
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                provider = MistralProvider(config=mock_config)
+                
+                # Create mock for stream response
+                mock_event_stream = MagicMock(spec=EventStream)
+                
+                # Create first chunk with tool call start
+                mock_chunk1 = MagicMock()
+                mock_choice1 = MagicMock()
+                mock_delta1 = MagicMock()
+                mock_delta1.content = "Let me check"
+                
+                # Create mock tool call for first chunk
+                mock_tool_call1 = MagicMock()
+                mock_function1 = MagicMock()
+                mock_function1.name = "get_weather"
+                mock_function1.arguments = '{"location"'
+                mock_tool_call1.function = mock_function1
+                mock_tool_call1.id = "call_abc123"
+                mock_delta1.tool_calls = [mock_tool_call1]
+                
+                mock_choice1.delta = mock_delta1
+                mock_choice1.finish_reason = None
+                mock_chunk1.data.choices = [mock_choice1]
+                
+                # Create second chunk with tool call completion
+                mock_chunk2 = MagicMock()
+                mock_choice2 = MagicMock()
+                mock_delta2 = MagicMock()
+                mock_delta2.content = ""
+                
+                # Create mock tool call for second chunk
+                mock_tool_call2 = MagicMock()
+                mock_function2 = MagicMock()
+                mock_function2.arguments = ': "New York"}'
+                mock_tool_call2.function = mock_function2
+                mock_delta2.tool_calls = [mock_tool_call2]
+                
+                mock_choice2.delta = mock_delta2
+                mock_choice2.finish_reason = "tool_calls"
+                mock_chunk2.data.choices = [mock_choice2]
+                
+                # Set up the mock event stream to yield our chunks
+                mock_event_stream.__iter__ = MagicMock(return_value=iter([mock_chunk1, mock_chunk2]))
+                
+                # Process the stream
+                responses = list(provider._handle_stream_response(mock_event_stream))
+                
+                # Verify responses
+                assert len(responses) == 2
+                assert responses[0].content == "Let me check"
+                assert responses[0].tool_call is None
+                
+                assert responses[1].content == ""
+                assert responses[1].finish_reason == "tool_calls"
+                assert responses[1].tool_call is not None
+                assert responses[1].tool_call.arguments == '{"location": "New York"}'
+    
+    def test_handle_normal_response_edge_case(self, mock_config):
+        """Test _handle_normal_response method with empty or invalid response"""
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                provider = MistralProvider(config=mock_config)
+
+                # Create a mock response with no choices
+                mock_response = MagicMock(spec=ChatCompletionResponse)
+                mock_response.choices = []
+                mock_response.model_dump_json = MagicMock(return_value='{"error": "no choices"}')
+
+                # Process the response
+                responses = list(provider._handle_normal_response(mock_response))
+
+                # Verify response handling for edge case
+                assert len(responses) == 1
+                assert responses[0].content == '{"error": "no choices"}'
+                assert responses[0].finish_reason == "stop"
+
+    def test_completion_with_verbose(self, mock_config):
+        """Test completion method with verbose flag enabled"""
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                # Enable verbose mode
+                provider = MistralProvider(config=mock_config, verbose=True)
+                
+                # Mock console
+                provider.console = MagicMock()
+                
+                # Mock _convert_messages method
+                provider._convert_messages = MagicMock(return_value=[{"role": "user", "content": "Hello"}])
+                
+                # Mock client.chat.complete method
+                mock_response = MagicMock(spec=ChatCompletionResponse)
+                mock_choice = MagicMock()
+                mock_message = MagicMock()
+                mock_message.content = "Test response"
+                mock_choice.message = mock_message
+                mock_choice.finish_reason = "stop"
+                mock_response.choices = [mock_choice]
+                
+                provider.client.chat.complete = MagicMock(return_value=mock_response)
+                
+                # Create test messages
+                messages = [ChatMessage(role="user", content="Hello")]
+                
+                # Call the completion method with streaming=False
+                list(provider.completion(messages, stream=False))
+                
+                # Verify console.print was called for verbose output
+                provider.console.print.assert_any_call("Messages:")
+                provider.console.print.assert_any_call([{"role": "user", "content": "Hello"}])
+    
+    def test_process_tool_call_chunk_with_dict_arguments(self, mock_config):
+        """Test _process_tool_call_chunk with dictionary arguments instead of string"""
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                provider = MistralProvider(config=mock_config)
+
+                # Create mock tool calls with dict arguments instead of string
+                mock_tool_call = MagicMock()
+                mock_function = MagicMock()
+                mock_function.name = "weather_function"
+                # Use a dict instead of a string for arguments
+                mock_function.arguments = {"location": "New York"}
+                mock_tool_call.function = mock_function
+                mock_tool_call.id = "call_123"
+
+                # Process the tool call
+                result = provider._process_tool_call_chunk([mock_tool_call])
+                
+                # Verify arguments were converted to JSON string
+                assert result.id == "call_123"
+                assert result.name == "weather_function"
+                assert result.arguments == '{"location": "New York"}'
+
+    def test_process_tool_call_chunk_with_no_function(self, mock_config):
+        """Test _process_tool_call_chunk with tool that has no function"""
+        with patch("mistralai.Mistral"):
+            with patch("warnings.filterwarnings"):
+                provider = MistralProvider(config=mock_config)
+
+                # Create a tool call with a missing function
+                mock_tool_call = MagicMock()
+                mock_tool_call.id = "call_456"
+                mock_tool_call.function = None
+                
+                # Create a valid tool call
+                mock_tool_call2 = MagicMock()
+                mock_function = MagicMock()
+                mock_function.name = "valid_function"
+                mock_function.arguments = '{"valid": true}'
+                mock_tool_call2.function = mock_function
+                mock_tool_call2.id = "call_123"
+
+                # Process both tool calls
+                existing_tool_call = ToolCall("call_123", "valid_function", "")
+                result = provider._process_tool_call_chunk([mock_tool_call, mock_tool_call2], existing_tool_call)
+                
+                # Verify valid function was processed and invalid one was skipped
+                assert result.id == "call_123"
+                assert result.name == "valid_function"
+                assert result.arguments == '{"valid": true}'

--- a/tests/llms/test_openai_provider.py
+++ b/tests/llms/test_openai_provider.py
@@ -53,7 +53,7 @@ class TestOpenAIProvider:
                 "default_headers": {
                     "X-Title": provider.APP_NAME,
                     "HTTP_Referer": provider.APP_REFERER,
-                }
+                },
             }
 
             # Check initialization of completion params

--- a/tests/llms/test_provider.py
+++ b/tests/llms/test_provider.py
@@ -1,3 +1,4 @@
+# type: ignore
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -67,6 +68,7 @@ class TestProviderFactory:
             "huggingface",
             "cohere-bedrock",
             "cohere-sagemaker",
+            "mistral",
         }
 
         assert set(ProviderFactory.providers_map.keys()) == expected_providers

--- a/tests/tools/test_mcp.py
+++ b/tests/tools/test_mcp.py
@@ -219,11 +219,11 @@ class TestMCPClient:
         ]
         mock_loop.run_until_complete.return_value = mock_tools
         mock_get_loop.return_value = mock_loop
-        
+
         # Mock the async methods to return regular Mock objects instead of coroutines
         mock_client_instance = Mock()
         mock_client_class.return_value = mock_client_instance
-        
+
         # Create client and call list_tools
         client = MCPClient()
         # Replace the _list_tools_async method with a mock that doesn't return a coroutine

--- a/uv.lock
+++ b/uv.lock
@@ -1796,6 +1796,20 @@ wheels = [
 ]
 
 [[package]]
+name = "tox-uv"
+version = "1.26.1"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
+dependencies = [
+    { name = "packaging" },
+    { name = "tox" },
+    { name = "uv" },
+]
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/cf/00/98e564731fc361cc2f1e39c58d2feb0b4c9f9a7cb06f0c769cdeb9a98004/tox_uv-1.26.1.tar.gz", hash = "sha256:241cc530b4a80436c4487977c8303d9aace398c6561d5e7d8845606fa7d482ab" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/fa/0b/e47c1bb2bc9e20b22a6913ea2162b7bb5729d38924fa2c1d4eaf95d3b36f/tox_uv-1.26.1-py3-none-any.whl", hash = "sha256:edc25b254e5cdbb13fc5d23d6d05b511dee562ab72b0e99da4a874a78018c38e" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
@@ -1862,6 +1876,31 @@ source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
 sdist = { url = "https://mirrors.aliyun.com/pypi/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466" }
 wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813" },
+]
+
+[[package]]
+name = "uv"
+version = "0.7.15"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/f2/e2/f4ae75e0d52abaf8c01c6948b423fbac7a6ae4413556a983959bf8f9b658/uv-0.7.15.tar.gz", hash = "sha256:c608cd2d89db7482ab40fc6e7de27afc87b20595e145ed81a2a8702e9a0d7e2d" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/3a/57/5bd08b88b583bde2daa54abaf418de1b0b6712bc60d5583a3cc9455174b3/uv-0.7.15-py3-none-linux_armv6l.whl", hash = "sha256:804b927f1b08f97ad597405276058bc94bab9e35c77e7f86c4ca635f72269ff8" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/3e/60/f8c159919b96ae9c77bd61f78d5e0dda2769840510abb4ebcc66750b2bb3/uv-0.7.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:33f57f51ff980a74131cc8cde501b8467faec21aef35518ff6b544450be2f9be" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/a1/4c/b36bc5e665d1466782a7687347291f1f148d78ea1bb1534114b6f8437098/uv-0.7.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:cc5ed8a4c804b6cacc13fdb794ff86fb6cca02b8966e075a9e15ea976c642454" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/13/13/ad63a01b2a6fc68b5b0bd5ddcaa99e997e4143233bd09b2db7b0f917c2f9/uv-0.7.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:cd374f9d4eca1b07662e2d774c710d18a7865a4387bc95e8d08fc9070473bb5f" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/7b/6c/073e8c8d2c1154f72a6323482b0a5388655622c2fe0867e47b4bb8893e3f/uv-0.7.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1d2d9cff6af77e9dd604782da785e271b7082ddf16636e34e0acee1689cc9392" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/4e/88/f019ebc681882cac372f403b4008389e7db3481516ae78ad23bb766f9959/uv-0.7.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0601b9757f70f0cb243963ba2c4241d1d9207f4b5afc63c68d609ac5e54ce657" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/7b/ee/b506ebdc89d9087ac3436eb7eb22c7ac8926eb199e5253769568316db112/uv-0.7.15-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:361b9b004e62a8d620b7eb79f51f9cc9f815ee0b287c2ce42fb3618f84172a2f" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/57/32/50b1e80b91ef2b4478217f6a1754c0888f1e90379b8fa77ed70d5f5f0ee9/uv-0.7.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:df99a0f54f8d0889879dee3fb99ec3d0748bbd42af31428197b5fe6b90b7b974" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/af/01/3a83831b8916ccb3ce22ac1295ba079f95ab74461236c379f8817a2bf47f/uv-0.7.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3cd980b68bbfc80ccc9fe8ab4fccec5350ec0be4135569d8c5bddb605a2fd390" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/06/65/90760c9c90633ee37bea46687edddb633f047002625fbb24d5dd43c7f465/uv-0.7.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2f6f78e6b816b9fb2cb92f1f1857dd7725cc2008d800e4f4cdc195f64f0c96c8" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/a8/e3/4552eb0f95beeb84c5d7d60aa184d62357194df71a8a2e34b8f78681890d/uv-0.7.15-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:7edac5d090bf9cb84bf0139ae48d3629384d94638b1e2215ca2441f786b9e8eb" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/93/75/a9d1301267f781c5d06df05dd8bb87884b7818f9dfcccb211716754b9805/uv-0.7.15-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:81201cf430e527fa88bcfa9a6adb91ad4080cf635684bbc456e4bb589cea6e3c" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/f2/ed/a199eb35aff558e3276a3c4591e1d7152a7fdd2d1b5dad60c21191748f72/uv-0.7.15-py3-none-musllinux_1_1_i686.whl", hash = "sha256:d78d1e9b05ab6e540ba4567b92d6f16f80176905183db8581d8b77522c39256c" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/7d/50/633fe84ac08ad7a233dc3b7113184af6bbfd0668078993b4408edf6fb767/uv-0.7.15-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:8717797f0d4b257a9d3f217959d24119342b0d96c2b224fbfefa44df5d94def2" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/5e/0a/5eee2e56063708a25d6d794153884b260d6f322649d3434f4d449fb65e6e/uv-0.7.15-py3-none-win32.whl", hash = "sha256:10ff8e18e617685f1b5ba4726da2782093ae7032e257eb500358444b610a92b1" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/be/73/d6d6fd05728263cc5bc81cf2424f2e78203fdd1b6c926f61363921bd8d8e/uv-0.7.15-py3-none-win_amd64.whl", hash = "sha256:9fda476ce40a428861e62b4e7c1d1199deb48ffc9b9197219e7f78e7c59be7a7" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/14/89/7f34a13ea6b336f3a0e70856bd584628556d03a865909a8a3854b7468239/uv-0.7.15-py3-none-win_arm64.whl", hash = "sha256:32a1ca819298b6cbe673becc3d52fc51a626ed003b61402824f1614d786650ac" },
 ]
 
 [[package]]
@@ -1995,6 +2034,7 @@ all = [
     { name = "cohere" },
     { name = "google-genai" },
     { name = "huggingface-hub" },
+    { name = "mistralai" },
     { name = "ollama" },
     { name = "volcengine-python-sdk" },
 ]
@@ -2024,6 +2064,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "tox" },
+    { name = "tox-uv" },
 ]
 
 [package.metadata]
@@ -2040,6 +2081,7 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.33.0" },
     { name = "instructor", specifier = ">=1.7.9" },
     { name = "json-repair", specifier = ">=0.44.1" },
+    { name = "mistralai", marker = "extra == 'all'", specifier = ">=1.8.2" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=1.8.2" },
     { name = "ollama", marker = "extra == 'all'", specifier = ">=0.5.1" },
     { name = "ollama", marker = "extra == 'ollama'", specifier = ">=0.5.1" },
@@ -2060,6 +2102,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "ruff", specifier = ">=0.11.2" },
     { name = "tox", specifier = ">=4.27.0" },
+    { name = "tox-uv", specifier = ">=1.26.1" },
 ]
 
 [[package]]

--- a/yaicli/const.py
+++ b/yaicli/const.py
@@ -69,7 +69,8 @@ DEFAULT_JUSTIFY: JustifyMethod = "default"
 DEFAULT_ROLE_MODIFY_WARNING: BOOL_STR = "true"
 DEFAULT_ENABLE_FUNCTIONS: BOOL_STR = "true"
 DEFAULT_SHOW_FUNCTION_OUTPUT: BOOL_STR = "true"
-DEFAULT_REASONING_EFFORT: Optional[Literal["low", "high", "medium"]] = None
+# low/high/medium for openai, default/null for groq
+DEFAULT_REASONING_EFFORT: Optional[Literal["low", "high", "medium", "default", "null"]] = None
 DEFAULT_ENABLE_MCP: BOOL_STR = "false"
 DEFAULT_SHOW_MCP_OUTPUT: BOOL_STR = "false"
 

--- a/yaicli/exceptions.py
+++ b/yaicli/exceptions.py
@@ -16,3 +16,7 @@ class ChatLoadError(YaicliError):
 
 class ChatDeleteError(YaicliError):
     """Error deleting chat"""
+
+
+class MCPToolsError(YaicliError):
+    """Error getting MCP tools"""

--- a/yaicli/llms/providers/ai21_provider.py
+++ b/yaicli/llms/providers/ai21_provider.py
@@ -1,4 +1,4 @@
-from typing import Dict, Generator, Optional
+from typing import Generator, Optional
 
 from openai._streaming import Stream
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
@@ -11,19 +11,14 @@ class AI21Provider(OpenAIProvider):
     """AI21 provider implementation based on openai-compatible API"""
 
     DEFAULT_BASE_URL = "https://api.ai21.com/studio/v1"
-
-    def get_completion_params_keys(self) -> Dict[str, str]:
-        """
-        Customize completion parameter keys for AI21 API.
-        Maps 'max_completion_tokens' to 'max_tokens' for compatibility.
-
-        Returns:
-            Dict[str, str]: Modified parameter mapping dictionary
-        """
-        keys = super().get_completion_params_keys()
-        if "max_completion_tokens" in keys:
-            keys["max_tokens"] = keys.pop("max_completion_tokens")
-        return keys
+    COMPLETION_PARAMS_KEYS = {
+        "model": "MODEL",
+        "temperature": "TEMPERATURE",
+        "top_p": "TOP_P",
+        "max_tokens": "MAX_TOKENS",
+        "timeout": "TIMEOUT",
+        "extra_body": "EXTRA_BODY",
+    }
 
     def _handle_stream_response(self, response: Stream[ChatCompletionChunk]) -> Generator[LLMResponse, None, None]:
         """Handle streaming response from AI21 models

--- a/yaicli/llms/providers/chutes_provider.py
+++ b/yaicli/llms/providers/chutes_provider.py
@@ -5,20 +5,11 @@ class ChutesProvider(OpenAIProvider):
     """Chutes provider implementation based on openai-compatible API"""
 
     DEFAULT_BASE_URL = "https://llm.chutes.ai/v1"
-
-    def get_completion_params_keys(self) -> dict:
-        """
-        Customize completion parameter keys for Chutes API.
-        Maps 'max_completion_tokens' to 'max_tokens' and removes 'reasoning_effort'
-        which is not supported by this provider.
-
-        Returns:
-            dict: Modified parameter mapping dictionary
-        """
-        keys = super().get_completion_params_keys()
-        # Replace max_completion_tokens with max_tokens in the API
-        if "max_completion_tokens" in keys:
-            keys["max_tokens"] = keys.pop("max_completion_tokens")
-        # Remove unsupported parameters
-        keys.pop("reasoning_effort", None)
-        return keys
+    COMPLETION_PARAMS_KEYS = {
+        "model": "MODEL",
+        "temperature": "TEMPERATURE",
+        "top_p": "TOP_P",
+        "max_tokens": "MAX_TOKENS",
+        "timeout": "TIMEOUT",
+        "extra_body": "EXTRA_BODY",
+    }

--- a/yaicli/llms/providers/deepseek_provider.py
+++ b/yaicli/llms/providers/deepseek_provider.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict
-
 from .openai_provider import OpenAIProvider
 
 
@@ -7,9 +5,11 @@ class DeepSeekProvider(OpenAIProvider):
     """DeepSeek provider implementation based on openai-compatible API"""
 
     DEFAULT_BASE_URL = "https://api.deepseek.com/v1"
-
-    def get_completion_params(self) -> Dict[str, Any]:
-        params = super().get_completion_params()
-        if "max_completion_tokens" in params:
-            params["max_tokens"] = params.pop("max_completion_tokens")
-        return params
+    COMPLETION_PARAMS_KEYS = {
+        "model": "MODEL",
+        "temperature": "TEMPERATURE",
+        "top_p": "TOP_P",
+        "max_tokens": "MAX_TOKENS",
+        "timeout": "TIMEOUT",
+        "extra_body": "EXTRA_BODY",
+    }

--- a/yaicli/llms/providers/infiniai_provider.py
+++ b/yaicli/llms/providers/infiniai_provider.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict
-
 from ...config import cfg
 from .openai_provider import OpenAIProvider
 
@@ -8,15 +6,17 @@ class InfiniAIProvider(OpenAIProvider):
     """InfiniAI provider implementation based on openai-compatible API"""
 
     DEFAULT_BASE_URL = "https://cloud.infini-ai.com/maas/v1"
+    COMPLETION_PARAMS_KEYS = {
+        "model": "MODEL",
+        "temperature": "TEMPERATURE",
+        "top_p": "TOP_P",
+        "max_tokens": "MAX_TOKENS",
+        "timeout": "TIMEOUT",
+        "extra_body": "EXTRA_BODY",
+    }
 
     def __init__(self, config: dict = cfg, **kwargs):
         super().__init__(config, **kwargs)
         if self.enable_function:
             self.console.print("InfiniAI does not support functions, disabled", style="yellow")
         self.enable_function = False
-
-    def get_completion_params(self) -> Dict[str, Any]:
-        params = super().get_completion_params()
-        if "max_completion_tokens" in params:
-            params["max_tokens"] = params.pop("max_completion_tokens")
-        return params

--- a/yaicli/llms/providers/minimax_provider.py
+++ b/yaicli/llms/providers/minimax_provider.py
@@ -5,17 +5,11 @@ class MinimaxProvider(OpenAIProvider):
     """Minimax provider implementation based on openai-compatible API"""
 
     DEFAULT_BASE_URL = "https://api.minimaxi.com/v1"
-
-    def get_completion_params_keys(self) -> dict:
-        """
-        Customize completion parameter keys for Minimax API.
-        Maps 'max_completion_tokens' to 'max_tokens' for compatibility.
-
-        Returns:
-            dict: Modified parameter mapping dictionary
-        """
-        keys = super().get_completion_params_keys()
-        # Replace max_completion_tokens with max_tokens in the API
-        if "max_completion_tokens" in keys:
-            keys["max_tokens"] = keys.pop("max_completion_tokens")
-        return keys
+    COMPLETION_PARAMS_KEYS = {
+        "model": "MODEL",
+        "temperature": "TEMPERATURE",
+        "top_p": "TOP_P",
+        "max_tokens": "MAX_TOKENS",
+        "timeout": "TIMEOUT",
+        "extra_body": "EXTRA_BODY",
+    }

--- a/yaicli/llms/providers/mistral_provider.py
+++ b/yaicli/llms/providers/mistral_provider.py
@@ -1,0 +1,217 @@
+import json
+from typing import Any, Dict, Generator, List, Optional, Union
+
+from mistralai import Mistral
+from mistralai.models import ChatCompletionResponse, CompletionEvent, ContentChunk
+from mistralai.models import ToolCall as MistralToolCall
+from mistralai.utils.eventstreaming import EventStream
+from pydantic import PydanticDeprecatedSince20, PydanticDeprecatedSince211
+
+from ...config import cfg
+from ...console import get_console
+from ...exceptions import MCPToolsError
+from ...schemas import ChatMessage, LLMResponse, ToolCall
+from ...tools import get_openai_mcp_tools, get_openai_schemas
+from ...utils import gen_tool_call_id
+from ..provider import Provider
+
+
+class MistralProvider(Provider):
+    """Mistral provider implementation based on mistralai library"""
+
+    CLIENT_CLS = Mistral
+    DEFAULT_BASE_URL = "https://api.mistral.ai/v1"
+
+    def __init__(self, config: dict = cfg, verbose: bool = False, **kwargs):
+        """Initialize Mistral provider
+
+        Args:
+            config: Configuration dictionary
+            verbose: Whether to enable verbose logging
+        """
+        self.config = config
+        self.verbose = verbose
+        self.enable_functions = config["ENABLE_FUNCTIONS"]
+        self.enable_mcp = config["ENABLE_MCP"]
+        self.client = Mistral(**self.get_client_params())
+        self.console = get_console()
+
+        # Disable pydantic deprecated warnings
+        import warnings
+
+        warnings.filterwarnings("ignore", category=PydanticDeprecatedSince20)
+        warnings.filterwarnings("ignore", category=PydanticDeprecatedSince211)
+
+    def get_client_params(self) -> Dict[str, Any]:
+        """Get client parameters for Mistral
+
+        Returns:
+            Dict[str, Any]
+        """
+        client_params = {
+            "api_key": self.config["API_KEY"],
+            "timeout_ms": self.config["TIMEOUT"] * 1000,  # Mistral uses milliseconds
+        }
+        if self.config["BASE_URL"]:
+            client_params["server_url"] = self.config["BASE_URL"]
+        if self.config.get("SERVER"):
+            client_params["server"] = self.config["SERVER"]
+        return client_params
+
+    def get_completion_params(self) -> Dict[str, Any]:
+        """Get completion parameters for Mistral
+
+        Returns:
+            Dict[str, Any]
+        """
+        params = {
+            "model": self.config["MODEL"],
+            "temperature": self.config["TEMPERATURE"],
+            "top_p": self.config["TOP_P"],
+            "max_tokens": self.config["MAX_TOKENS"],
+            "stream": self.config["STREAM"],
+            "http_headers": {
+                "X-Title": self.APP_NAME,
+                "HTTP_Referer": self.APP_REFERER,
+            },
+        }
+        if self.config["EXTRA_HEADERS"]:
+            params["http_headers"] = {**self.config["EXTRA_HEADERS"], **params["http_headers"]}
+        tools = []
+        if self.enable_functions:
+            tools.extend(get_openai_schemas())
+        if self.enable_mcp:
+            try:
+                tools.extend(get_openai_mcp_tools())
+            except MCPToolsError as e:
+                self.console.print(e, style="red")
+        if tools:
+            params["tools"] = tools
+            params["tool_choice"] = "auto"
+            params["parallel_tool_calls"] = False
+        return params
+
+    def completion(self, messages: List[ChatMessage], stream: bool = False) -> Generator[LLMResponse, None, None]:
+        """Completion method for Mistral
+
+        Args:
+            messages: List of ChatMessage
+            stream: Whether to stream the response
+        """
+        # Convert messages to Mistral format
+        mistral_messages = self._convert_messages(messages)
+        if self.verbose:
+            self.console.print("Messages:")
+            self.console.print(mistral_messages)
+
+        params = self.get_completion_params()
+        params["messages"] = mistral_messages
+
+        if stream:
+            response = self.client.chat.stream(**params)
+            yield from self._handle_stream_response(response)
+        else:
+            response = self.client.chat.complete(**params)
+            yield from self._handle_normal_response(response)
+
+    def _handle_normal_response(self, response: ChatCompletionResponse) -> Generator[LLMResponse, None, None]:
+        """Handle normal (non-streaming) response"""
+        if not response.choices or not response.choices[0].message:
+            content = response.model_dump_json()
+            yield LLMResponse(content=content, finish_reason="stop")
+            return
+
+        choice = response.choices[0]
+        finish_reason = choice.finish_reason
+        content = self.get_content_from_delta_content(choice.message.content) if choice.message.content else ""
+        tool_call: Optional[ToolCall] = None
+
+        # Handle tool calls if present
+        if finish_reason == "tool_calls":
+            tool_call = self._process_tool_call_chunk(choice.message.tool_calls or [])
+
+        yield LLMResponse(content=content, finish_reason=finish_reason, tool_call=tool_call)
+
+    def _handle_stream_response(self, response: EventStream[CompletionEvent]) -> Generator[LLMResponse, None, None]:
+        """Handle stream response"""
+        tool_call: Optional[ToolCall] = None
+
+        for chunk in response:
+            choice = chunk.data.choices[0]
+            finish_reason = choice.finish_reason
+            delta_content = choice.delta.content
+            delta = choice.delta
+            content = ""
+
+            if delta_content:
+                content = self.get_content_from_delta_content(delta_content)
+
+            # Process tool call information
+            if hasattr(delta, "tool_calls") and delta.tool_calls:
+                tool_call = self._process_tool_call_chunk(delta.tool_calls, tool_call)
+
+            yield LLMResponse(
+                content=content,
+                finish_reason=finish_reason,
+                tool_call=tool_call if finish_reason == "tool_calls" else None,
+            )
+
+    def _process_tool_call_chunk(
+        self, tool_calls: List[MistralToolCall], existing_tool_call: Optional[ToolCall] = None
+    ) -> Optional[ToolCall]:
+        """Process tool call data from a response chunk"""
+        # Initialize tool call object if this is the first chunk with tool call data
+        if existing_tool_call is None and tool_calls:
+            tool = tool_calls[0]
+            existing_tool_call = ToolCall(tool.id or gen_tool_call_id(), tool.function.name, "")
+
+        # Accumulate arguments from multiple chunks
+        if existing_tool_call:
+            for tool in tool_calls:
+                if not tool.function:
+                    continue
+                # Ensure arguments is a string
+                tool_args = tool.function.arguments
+                if not isinstance(tool_args, str):
+                    tool_args = json.dumps(tool_args)
+                existing_tool_call.arguments += tool_args
+
+        return existing_tool_call
+
+    def get_content_from_delta_content(self, delta_content: Union[str, List[ContentChunk]]) -> str:
+        """Get content from a delta content
+
+        If the delta content is a string, it will be returned as is.
+        If the delta content is a list of ContentChunk, it will be converted to a string.
+        Args:
+            delta_content: Union[str, List[ContentChunk]]
+        Returns:
+            str
+        """
+        if isinstance(delta_content, str):
+            return delta_content
+        return self.extract_contents_list(delta_content)
+
+    def extract_contents_list(self, delta_content: List[ContentChunk]) -> str:
+        """Extract content from a list of ContentChunk
+
+        If the content is a list of ContentChunk, it will be converted to a string.
+        Args:
+            delta_content: List[ContentChunk]
+        Returns:
+            str
+        """
+        content = ""
+        for i in delta_content:
+            if i.type == "text":
+                content += i.text
+            elif i.type == "image_url":
+                content += i.image_url if isinstance(i.image_url, str) else i.image_url.url
+            elif i.type == "document_url":
+                content += f"[{i.document_name}]({i.document_url})"
+            elif i.type == "reference":
+                content += "Reference IDs: " + json.dumps(i.reference_ids)
+        return content
+
+    def detect_tool_role(self) -> str:
+        return "tool"

--- a/yaicli/llms/providers/modelscope_provider.py
+++ b/yaicli/llms/providers/modelscope_provider.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict
-
 from .openai_provider import OpenAIProvider
 
 
@@ -7,9 +5,11 @@ class ModelScopeProvider(OpenAIProvider):
     """ModelScope provider implementation based on openai-compatible API"""
 
     DEFAULT_BASE_URL = "https://api-inference.modelscope.cn/v1/"
-
-    def get_completion_params(self) -> Dict[str, Any]:
-        params = super().get_completion_params()
-        if "max_completion_tokens" in params:
-            params["max_tokens"] = params.pop("max_completion_tokens")
-        return params
+    COMPLETION_PARAMS_KEYS = {
+        "model": "MODEL",
+        "temperature": "TEMPERATURE",
+        "top_p": "TOP_P",
+        "max_tokens": "MAX_TOKENS",
+        "timeout": "TIMEOUT",
+        "extra_body": "EXTRA_BODY",
+    }

--- a/yaicli/llms/providers/ollama_provider.py
+++ b/yaicli/llms/providers/ollama_provider.py
@@ -3,6 +3,7 @@ import time
 from typing import Any, Dict, Generator, List
 
 import ollama
+from ollama import ChatResponse
 
 from ...config import cfg
 from ...console import get_console
@@ -50,7 +51,7 @@ class OllamaProvider(Provider):
         """Convert a list of ChatMessage objects to a list of Ollama message dicts."""
         converted_messages = []
         for msg in messages:
-            message = {"role": msg.role, "content": msg.content or ""}
+            message: dict[str, Any] = {"role": msg.role, "content": msg.content or ""}
 
             if msg.name:
                 message["name"] = msg.name
@@ -118,7 +119,7 @@ class OllamaProvider(Provider):
             self.console.print(f"Ollama API error: {e}", style="red")
             yield LLMResponse(content=f"Error calling Ollama API: {str(e)}")
 
-    def _handle_normal_response(self, response: Dict[str, Any]) -> Generator[LLMResponse, None, None]:
+    def _handle_normal_response(self, response: ChatResponse) -> Generator[LLMResponse, None, None]:
         """Handle normal (non-streaming) response"""
         content = response.message.content or ""
         reasoning = response.message.thinking or ""

--- a/yaicli/llms/providers/openrouter_provider.py
+++ b/yaicli/llms/providers/openrouter_provider.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from .openai_provider import OpenAIProvider
 
 
@@ -7,16 +5,11 @@ class OpenRouterProvider(OpenAIProvider):
     """OpenRouter provider implementation based on openai-compatible API"""
 
     DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
-
-    def get_completion_params_keys(self) -> Dict[str, str]:
-        """
-        Customize completion parameter keys for OpenRouter API.
-        Maps 'max_completion_tokens' to 'max_tokens' for compatibility.
-
-        Returns:
-            Dict[str, str]: Modified parameter mapping dictionary
-        """
-        keys = super().get_completion_params_keys()
-        if "max_completion_tokens" in keys:
-            keys["max_tokens"] = keys.pop("max_completion_tokens")
-        return keys
+    COMPLETION_PARAMS_KEYS = {
+        "model": "MODEL",
+        "temperature": "TEMPERATURE",
+        "top_p": "TOP_P",
+        "max_tokens": "MAX_TOKENS",
+        "timeout": "TIMEOUT",
+        "extra_body": "EXTRA_BODY",
+    }

--- a/yaicli/llms/providers/sambanova_provider.py
+++ b/yaicli/llms/providers/sambanova_provider.py
@@ -16,23 +16,14 @@ class SambanovaProvider(OpenAIProvider):
         "DeepSeek-V3-0324",
     )
 
-    def get_completion_params_keys(self) -> Dict[str, str]:
-        """
-        Customize completion parameter keys for Sambanova API.
-        Maps 'max_completion_tokens' to 'max_tokens' for compatibility
-        and removes parameters not supported by Sambanova.
-
-        Returns:
-            Dict[str, str]: Modified parameter mapping dictionary
-        """
-        keys = super().get_completion_params_keys()
-        # Replace max_completion_tokens with max_tokens
-        if "max_completion_tokens" in keys:
-            keys["max_tokens"] = keys.pop("max_completion_tokens")
-        # Remove unsupported parameters
-        keys.pop("presence_penalty", None)
-        keys.pop("frequency_penalty", None)
-        return keys
+    COMPLETION_PARAMS_KEYS = {
+        "model": "MODEL",
+        "temperature": "TEMPERATURE",
+        "top_p": "TOP_P",
+        "max_tokens": "MAX_TOKENS",
+        "timeout": "TIMEOUT",
+        "extra_body": "EXTRA_BODY",
+    }
 
     def get_completion_params(self) -> Dict[str, Any]:
         """

--- a/yaicli/llms/providers/siliconflow_provider.py
+++ b/yaicli/llms/providers/siliconflow_provider.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict
-
 from .openai_provider import OpenAIProvider
 
 
@@ -7,9 +5,11 @@ class SiliconFlowProvider(OpenAIProvider):
     """SiliconFlow provider implementation based on openai-compatible API"""
 
     DEFAULT_BASE_URL = "https://api.siliconflow.cn/v1"
-
-    def get_completion_params(self) -> Dict[str, Any]:
-        params = super().get_completion_params()
-        if "max_completion_tokens" in params:
-            params["max_tokens"] = params.pop("max_completion_tokens")
-        return params
+    COMPLETION_PARAMS_KEYS = {
+        "model": "MODEL",
+        "temperature": "TEMPERATURE",
+        "top_p": "TOP_P",
+        "max_tokens": "MAX_TOKENS",
+        "timeout": "TIMEOUT",
+        "extra_body": "EXTRA_BODY",
+    }

--- a/yaicli/llms/providers/targon_provider.py
+++ b/yaicli/llms/providers/targon_provider.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from .openai_provider import OpenAIProvider
 
 
@@ -7,16 +5,11 @@ class TargonProvider(OpenAIProvider):
     """Targon provider implementation based on openai-compatible API"""
 
     DEFAULT_BASE_URL = "https://api.targon.com/v1"
-
-    def get_completion_params_keys(self) -> Dict[str, str]:
-        """
-        Customize completion parameter keys for Targon API.
-        Maps 'max_completion_tokens' to 'max_tokens' for compatibility.
-
-        Returns:
-            Dict[str, str]: Modified parameter mapping dictionary
-        """
-        keys = super().get_completion_params_keys()
-        if "max_completion_tokens" in keys:
-            keys["max_tokens"] = keys.pop("max_completion_tokens")
-        return keys
+    COMPLETION_PARAMS_KEYS = {
+        "model": "MODEL",
+        "temperature": "TEMPERATURE",
+        "top_p": "TOP_P",
+        "max_tokens": "MAX_TOKENS",
+        "timeout": "TIMEOUT",
+        "extra_body": "EXTRA_BODY",
+    }

--- a/yaicli/llms/providers/yi_provider.py
+++ b/yaicli/llms/providers/yi_provider.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from .openai_provider import OpenAIProvider
 
 
@@ -7,16 +5,11 @@ class YiProvider(OpenAIProvider):
     """Lingyiwanwu provider implementation based on openai-compatible API"""
 
     DEFAULT_BASE_URL = "https://api.lingyiwanwu.com/v1"
-
-    def get_completion_params_keys(self) -> Dict[str, str]:
-        """
-        Customize completion parameter keys for Yi API.
-        Maps 'max_completion_tokens' to 'max_tokens' for compatibility.
-
-        Returns:
-            Dict[str, str]: Modified parameter mapping dictionary
-        """
-        keys = super().get_completion_params_keys()
-        if "max_completion_tokens" in keys:
-            keys["max_tokens"] = keys.pop("max_completion_tokens")
-        return keys
+    COMPLETION_PARAMS_KEYS = {
+        "model": "MODEL",
+        "temperature": "TEMPERATURE",
+        "top_p": "TOP_P",
+        "max_tokens": "MAX_TOKENS",
+        "timeout": "TIMEOUT",
+        "extra_body": "EXTRA_BODY",
+    }

--- a/yaicli/tools/mcp.py
+++ b/yaicli/tools/mcp.py
@@ -200,6 +200,10 @@ class MCPClient:
         This property will be lazy loaded.
         Returns:
             List[Tool]: Tool object list from fastmcp.types.Tool
+        Raises:
+            ValueError: If error getting MCP tools
+            FileNotFoundError: If MCP config file not found
+            RuntimeError: If called while the client is not connected.
         """
         if self._tools is None:
             self._tools = self.list_tools()
@@ -213,6 +217,10 @@ class MCPClient:
         This property will be lazy loaded.
         Returns:
             Dict[str, MCP]: MCP tool object mapping
+        Raises:
+            ValueError: If error getting MCP tools
+            FileNotFoundError: If MCP config file not found
+            RuntimeError: If called while the client is not connected.
         """
         if self._tools_map is None:
             self._tools_map = {}

--- a/yaicli/utils.py
+++ b/yaicli/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import platform
+import uuid
 from functools import wraps
 from os import getenv
 from os.path import basename, pathsep
@@ -166,3 +167,8 @@ def wrap_function(func: Callable) -> Callable:
         return func(*args, **kwargs)
 
     return wrapper
+
+
+def gen_tool_call_id() -> str:
+    """Generate a unique tool call id"""
+    return f"yaicli_{uuid.uuid4()}"


### PR DESCRIPTION
- **refactor: standardize completion parameter keys across providers**
- **fix: handle errors in get_openai_mcp_tools and MCPClient methods**
- **chore: add mistralai and tox-uv dependencies**
- **feat: add MCP tools error handling and reasoning effort options**
- **test: add tests for MistralProvider and update imports**
- **docs: add Mistral to README**
