### PR TITLE
feat: support DeepSeek thinking mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 
 ---
+## [0.15.2](https://github.com/belingud/yaicli/compare/v0.15.1..v0.15.2) - 2026-04-28
+
+### 🐛 Bug Fixes
+
+- fix: add tool_policy parameter to completion params - ([a47d619](https://github.com/belingud/yaicli/commit/a47d619ee7dfa5de2e4e2e30ab74cc385149608f)) - Belingud
+- fix: fall back to httpx when trafilatura extraction fails - ([1bdd254](https://github.com/belingud/yaicli/commit/1bdd2549b3ec86ecb0aec16b922fbbac2de629cd)) - Belingud
+
+
+---
+## [0.15.2](https://github.com/belingud/yaicli/compare/v0.15.1..v0.15.2) - 2026-04-28
+
+### 🐛 Bug Fixes
+
+- fix: add tool_policy parameter to completion params - ([a47d619](https://github.com/belingud/yaicli/commit/a47d619ee7dfa5de2e4e2e30ab74cc385149608f)) - Belingud
+- fix: fall back to httpx when trafilatura extraction fails - ([1bdd254](https://github.com/belingud/yaicli/commit/1bdd2549b3ec86ecb0aec16b922fbbac2de629cd)) - Belingud
+
+
+---
 ## [0.15.0](https://github.com/belingud/yaicli/compare/v0.14.2..v0.15.0) - 2026-03-24
 
 ### ⛰️  Features

--- a/README.md
+++ b/README.md
@@ -328,6 +328,27 @@ API_KEY=
 MODEL=deepseek-chat
 ```
 
+Thinking mode can be controlled with the existing `EXTRA_BODY` and `REASONING_EFFORT` settings. DeepSeek enables
+thinking by default for supported thinking models, so this is only needed when you want to be explicit or set effort:
+
+```ini
+PROVIDER=deepseek
+API_KEY=
+MODEL=deepseek-v4-pro
+REASONING_EFFORT=high
+EXTRA_BODY={"thinking":{"type":"enabled"}}
+```
+
+To disable thinking mode:
+
+```ini
+EXTRA_BODY={"thinking":{"type":"disabled"}}
+```
+
+When thinking mode is enabled, DeepSeek returns `reasoning_content`, which YAICLI displays as reasoning output and
+preserves during live tool-call conversations. DeepSeek ignores `temperature`, `top_p`, `presence_penalty`, and
+`frequency_penalty` while thinking is enabled.
+
 #### OpenRouter
 
 ```ini

--- a/docs/providers/deepseek.md
+++ b/docs/providers/deepseek.md
@@ -12,6 +12,24 @@ TEMPERATURE=0.3
 MAX_TOKENS=1024
 ```
 
+### Thinking Mode
+
+DeepSeek thinking mode can be controlled with the existing `EXTRA_BODY` and `REASONING_EFFORT` settings:
+
+```ini
+PROVIDER=deepseek
+API_KEY=sk-your-deepseek-api-key
+MODEL=deepseek-v4-pro
+REASONING_EFFORT=high
+EXTRA_BODY={"thinking":{"type":"enabled"}}
+```
+
+To explicitly disable thinking mode:
+
+```ini
+EXTRA_BODY={"thinking":{"type":"disabled"}}
+```
+
 ## Key Parameters
 
 | Parameter     | Description                   | Default                       |
@@ -24,6 +42,7 @@ MAX_TOKENS=1024
 | `TIMEOUT`     | Request timeout (seconds)     | `60`                          |
 | `BASE_URL`    | Custom API endpoint           | `https://api.deepseek.com/v1` |
 | `EXTRA_BODY`  | Additional request parameters | `{}`                          |
+| `REASONING_EFFORT` | Thinking effort (`high` or `max` for DeepSeek thinking models) | - |
 
 ## Features
 
@@ -38,5 +57,8 @@ MAX_TOKENS=1024
 
 - Uses OpenAI-compatible client implementation
 - Supports standard OpenAI API features
+- Thinking mode returns `reasoning_content`, which YAICLI displays as reasoning output
+- In thinking mode, DeepSeek ignores `temperature`, `top_p`, `presence_penalty`, and `frequency_penalty`
+- Live tool-call conversations preserve DeepSeek `reasoning_content` for follow-up requests; saved chat files do not yet persist full reasoning/tool metadata for exact replay after reload
 - Designed for coding and reasoning tasks
 - Cost-effective alternative to other providers

--- a/openspec/changes/archive/2026-05-10-support-deepseek-thinking-mode/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-10-support-deepseek-thinking-mode/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-10

--- a/openspec/changes/archive/2026-05-10-support-deepseek-thinking-mode/design.md
+++ b/openspec/changes/archive/2026-05-10-support-deepseek-thinking-mode/design.md
@@ -1,0 +1,96 @@
+## Context
+
+YAICLI represents model reasoning internally as `ChatMessage.reasoning` and `LLMResponse.reasoning`. OpenAI-compatible providers share the base `Provider._convert_messages()` implementation, which serializes assistant reasoning as `reasoning`.
+
+DeepSeek's thinking mode uses a different wire field: responses return `reasoning_content`, and follow-up requests must replay assistant reasoning as `reasoning_content` when tool calls occurred in the conversation. The current response parsing already extracts `reasoning_content`, but the replay path sends the wrong field name for DeepSeek.
+
+DeepSeek also exposes thinking intensity through the OpenAI-format `reasoning_effort` request parameter. The generic OpenAI provider supports this parameter, but the current DeepSeek provider parameter map does not include it.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Allow DeepSeek users to configure thinking mode through existing `EXTRA_BODY` and `REASONING_EFFORT` settings.
+- Preserve DeepSeek `reasoning_content` in request replay for assistant messages stored in YAICLI history.
+- Keep the fix provider-scoped so other OpenAI-compatible providers continue to use their current message formats.
+- Cover normal and tool-call DeepSeek message conversion with unit tests.
+- Document the DeepSeek thinking configuration and known ignored sampling parameters.
+
+**Non-Goals:**
+
+- Add a new DeepSeek-specific CLI flag or configuration key for thinking mode.
+- Change YAICLI's internal `ChatMessage.reasoning` data model.
+- Redesign saved chat persistence for tool calls and reasoning metadata.
+- Implement Anthropic-format DeepSeek thinking controls.
+- Make real DeepSeek API calls in tests.
+
+## Decisions
+
+### D1: Use existing configuration keys for thinking controls
+
+**Choice:** Keep `EXTRA_BODY` as the way to send `{"thinking": {"type": "enabled"}}` or `{"thinking": {"type": "disabled"}}`, and add `reasoning_effort` to DeepSeek's existing completion parameter map.
+
+**Alternative considered:** Add new config keys such as `DEEPSEEK_THINKING` and `DEEPSEEK_REASONING_EFFORT`.
+
+**Rationale:** YAICLI already has generic config paths for provider-specific request body fields and reasoning effort. Reusing them avoids new config surface area and matches the current provider architecture.
+
+### D2: Do not force-enable thinking in the provider
+
+**Choice:** The provider should not inject a `thinking` object when the user has not configured one.
+
+**Alternative considered:** Automatically add `{"thinking": {"type": "enabled"}}` to every DeepSeek request.
+
+**Rationale:** DeepSeek documents thinking as enabled by default for supported thinking models, and not every DeepSeek-compatible model necessarily accepts the same controls. Preserving explicit user config is safer and keeps non-thinking DeepSeek usage unchanged.
+
+### D3: Override only DeepSeek message conversion
+
+**Choice:** `DeepSeekProvider` should override `_convert_messages()` and serialize assistant reasoning as `reasoning_content`.
+
+**Alternative considered:** Change the base `Provider._convert_messages()` implementation from `reasoning` to `reasoning_content`.
+
+**Rationale:** Other providers already rely on provider-specific reasoning formats. A global field-name change risks breaking OpenRouter, MiniMax, and other OpenAI-compatible endpoints. DeepSeek is the provider with a documented requirement for `reasoning_content` replay.
+
+### D4: Replay all stored assistant reasoning as `reasoning_content`
+
+**Choice:** When a DeepSeek assistant message has `ChatMessage.reasoning`, serialize it as `reasoning_content` whether or not the message also has tool calls.
+
+**Alternative considered:** Only serialize reasoning for assistant messages with tool calls.
+
+**Rationale:** DeepSeek requires reasoning replay when tool calls occurred, and the API ignores unnecessary reasoning content in ordinary multi-turn conversations. Replaying all stored assistant reasoning keeps conversion simple and avoids incorrectly dropping a reasoning segment from a multi-step tool turn.
+
+### D5: Keep response parsing in the base OpenAI provider
+
+**Choice:** Continue using the existing extraction of `reasoning_content` from normal responses and stream deltas.
+
+**Alternative considered:** Duplicate response parsing in `DeepSeekProvider`.
+
+**Rationale:** Existing tests already cover the generic extraction path, and the current behavior maps DeepSeek's response field into `LLMResponse.reasoning`. The missing behavior is outbound replay, not inbound parsing.
+
+## Risks / Trade-offs
+
+**[Saved chat sessions lose reasoning and tool metadata]** -> A persisted chat resumed after a DeepSeek tool-call thinking turn may not contain enough metadata to replay the exact API-required context. Mitigation: keep this change scoped to live request compatibility and call out persistence as a follow-up if needed.
+
+**[Provider-specific parameter support varies by model]** -> Some DeepSeek models may ignore or reject thinking controls differently. Mitigation: do not auto-inject thinking controls; only forward user-configured values.
+
+**[Sampling parameters are ignored in thinking mode]** -> Users may expect `temperature`, `top_p`, or penalties to affect thinking responses. Mitigation: document that DeepSeek ignores these parameters while thinking is enabled.
+
+**[Reasoning replay can add tokens]** -> Replaying reasoning on ordinary non-tool turns may add request payload size, even if DeepSeek ignores it. Mitigation: keep behavior limited to stored assistant reasoning and rely on DeepSeek's documented ignore behavior for non-tool multi-turn contexts.
+
+## Migration Plan
+
+No data migration is required.
+
+Implementation sequence:
+
+1. Update `DeepSeekProvider.COMPLETION_PARAMS_KEYS` to include `reasoning_effort`.
+2. Add a DeepSeek-specific `_convert_messages()` implementation that emits `reasoning_content` for assistant reasoning.
+3. Add unit tests for completion parameters and message conversion with reasoning plus tool calls.
+4. Update DeepSeek provider documentation with thinking mode configuration examples and limitations.
+
+Rollback strategy:
+
+- Revert the DeepSeek provider and documentation changes. No persisted state changes are introduced.
+
+## Open Questions
+
+- Whether saved chat persistence should later store `reasoning`, `tool_calls`, and `tool_call_id` for exact provider replay after reload. This is broader than DeepSeek thinking and remains outside this change.

--- a/openspec/changes/archive/2026-05-10-support-deepseek-thinking-mode/proposal.md
+++ b/openspec/changes/archive/2026-05-10-support-deepseek-thinking-mode/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+DeepSeek's thinking mode returns and requires `reasoning_content`, but YAICLI currently serializes stored assistant reasoning as `reasoning` for OpenAI-format messages. This can break DeepSeek thinking conversations with tool calls because the API requires `reasoning_content` to be replayed in later turns.
+
+## What Changes
+
+- Add DeepSeek-specific request support for `REASONING_EFFORT` so users can set thinking intensity through existing configuration.
+- Preserve user-provided `EXTRA_BODY` while allowing `{"thinking": {"type": "enabled"}}` to be sent to DeepSeek through the existing config path.
+- Convert stored assistant reasoning back to `reasoning_content` for DeepSeek messages, especially assistant messages that include tool calls.
+- Keep existing response parsing and reasoning display behavior, which already maps `reasoning_content` into YAICLI's internal reasoning field.
+- Add tests covering DeepSeek completion params, message conversion, and tool-call reasoning replay.
+- Document how to configure DeepSeek thinking mode and note parameters that DeepSeek ignores while thinking is enabled.
+
+## Capabilities
+
+### New Capabilities
+
+- `deepseek-thinking-mode`: Defines how YAICLI enables DeepSeek thinking mode, forwards thinking intensity, and preserves DeepSeek `reasoning_content` across normal and tool-call turns.
+
+### Modified Capabilities
+
+(none -- existing specs do not cover provider-specific thinking behavior)
+
+## Impact
+
+- **DeepSeek provider** (`yaicli/llms/providers/deepseek_provider.py`): add provider-specific parameter mapping and message conversion.
+- **Message conversion contract** (`ChatMessage.reasoning` to provider payload): ensure DeepSeek receives `reasoning_content` rather than the generic `reasoning` field.
+- **Tests** (`tests/llms/`): add focused DeepSeek provider coverage without real API calls.
+- **Documentation** (`docs/providers/deepseek.md`, README provider examples if needed): describe thinking configuration and limitations.

--- a/openspec/changes/archive/2026-05-10-support-deepseek-thinking-mode/specs/deepseek-thinking-mode/spec.md
+++ b/openspec/changes/archive/2026-05-10-support-deepseek-thinking-mode/specs/deepseek-thinking-mode/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: DeepSeek thinking request parameters
+YAICLI SHALL allow DeepSeek requests to include thinking mode controls through existing configuration.
+
+#### Scenario: Forward thinking configuration
+- **WHEN** the DeepSeek provider is configured with `EXTRA_BODY={"thinking":{"type":"enabled"}}`
+- **THEN** the DeepSeek completion request MUST include that `extra_body` value unchanged
+
+#### Scenario: Forward reasoning effort
+- **WHEN** the DeepSeek provider is configured with `REASONING_EFFORT=high`
+- **THEN** the DeepSeek completion request MUST include `reasoning_effort` with value `high`
+
+#### Scenario: Preserve disabled thinking configuration
+- **WHEN** the DeepSeek provider is configured with `EXTRA_BODY={"thinking":{"type":"disabled"}}`
+- **THEN** the DeepSeek completion request MUST preserve `thinking.type` as `disabled`
+
+### Requirement: DeepSeek reasoning response handling
+YAICLI SHALL expose DeepSeek `reasoning_content` responses through its internal reasoning stream.
+
+#### Scenario: Non-streaming reasoning content
+- **WHEN** a DeepSeek non-streaming response message contains `reasoning_content`
+- **THEN** YAICLI MUST emit an `LLMResponse` whose `reasoning` contains that value
+
+#### Scenario: Streaming reasoning content
+- **WHEN** a DeepSeek streaming delta contains `reasoning_content`
+- **THEN** YAICLI MUST emit an `LLMResponse` chunk whose `reasoning` contains that delta value
+
+### Requirement: DeepSeek reasoning replay
+YAICLI SHALL serialize stored assistant reasoning as DeepSeek `reasoning_content` when sending conversation history to DeepSeek.
+
+#### Scenario: Assistant reasoning without tool calls
+- **WHEN** a stored assistant message has `reasoning` and no tool calls
+- **THEN** the DeepSeek message payload MUST contain `reasoning_content`
+- **AND** the DeepSeek message payload MUST NOT contain the generic `reasoning` field
+
+#### Scenario: Assistant reasoning with tool calls
+- **WHEN** a stored assistant message has `reasoning` and one or more tool calls
+- **THEN** the DeepSeek message payload MUST contain `reasoning_content`
+- **AND** the DeepSeek message payload MUST preserve the assistant `tool_calls`
+- **AND** the DeepSeek message payload MUST NOT contain the generic `reasoning` field
+
+#### Scenario: Tool response replay
+- **WHEN** a stored tool response references a DeepSeek assistant tool call by `tool_call_id`
+- **THEN** the DeepSeek message payload MUST preserve that `tool_call_id`
+
+### Requirement: Provider-scoped compatibility
+YAICLI SHALL implement DeepSeek thinking replay without changing the message format of unrelated providers.
+
+#### Scenario: Generic OpenAI-compatible providers
+- **WHEN** a non-DeepSeek OpenAI-format provider converts an assistant message with `reasoning`
+- **THEN** its existing provider-specific reasoning field behavior MUST remain unchanged

--- a/openspec/changes/archive/2026-05-10-support-deepseek-thinking-mode/tasks.md
+++ b/openspec/changes/archive/2026-05-10-support-deepseek-thinking-mode/tasks.md
@@ -1,0 +1,28 @@
+## 1. DeepSeek Provider
+
+- [x] 1.1 Add `reasoning_effort` to `DeepSeekProvider.COMPLETION_PARAMS_KEYS`.
+- [x] 1.2 Add DeepSeek-specific message conversion that serializes assistant `reasoning` as `reasoning_content`.
+- [x] 1.3 Ensure DeepSeek assistant messages with tool calls preserve `tool_calls` while using `reasoning_content`.
+- [x] 1.4 Ensure DeepSeek tool response messages preserve `tool_call_id`.
+
+## 2. Tests
+
+- [x] 2.1 Add DeepSeek provider tests for forwarding `EXTRA_BODY` thinking controls unchanged.
+- [x] 2.2 Add DeepSeek provider tests for forwarding `REASONING_EFFORT`.
+- [x] 2.3 Add DeepSeek message conversion tests for assistant reasoning without tool calls.
+- [x] 2.4 Add DeepSeek message conversion tests for assistant reasoning with tool calls.
+- [x] 2.5 Add DeepSeek message conversion tests for tool response replay.
+- [x] 2.6 Add or reuse response parsing tests proving DeepSeek `reasoning_content` maps to `LLMResponse.reasoning`.
+
+## 3. Documentation
+
+- [x] 3.1 Update DeepSeek provider docs with thinking mode configuration examples.
+- [x] 3.2 Document that DeepSeek thinking mode ignores `temperature`, `top_p`, `presence_penalty`, and `frequency_penalty`.
+- [x] 3.3 Document that saved chat replay of reasoning and tool metadata is outside this change if not implemented.
+- [x] 3.4 Update README DeepSeek provider section with thinking mode configuration.
+
+## 4. Verification
+
+- [x] 4.1 Run targeted DeepSeek/OpenAI provider tests.
+- [x] 4.2 Run formatting or lint checks for touched Python files.
+- [x] 4.3 Run OpenSpec status or validation for `support-deepseek-thinking-mode`.

--- a/openspec/specs/deepseek-thinking-mode/spec.md
+++ b/openspec/specs/deepseek-thinking-mode/spec.md
@@ -1,0 +1,57 @@
+# deepseek-thinking-mode Specification
+
+## Purpose
+Define YAICLI's DeepSeek thinking-mode behavior, including request controls, reasoning output handling, and
+conversation replay requirements for tool-call turns.
+
+## Requirements
+### Requirement: DeepSeek thinking request parameters
+YAICLI SHALL allow DeepSeek requests to include thinking mode controls through existing configuration.
+
+#### Scenario: Forward thinking configuration
+- **WHEN** the DeepSeek provider is configured with `EXTRA_BODY={"thinking":{"type":"enabled"}}`
+- **THEN** the DeepSeek completion request MUST include that `extra_body` value unchanged
+
+#### Scenario: Forward reasoning effort
+- **WHEN** the DeepSeek provider is configured with `REASONING_EFFORT=high`
+- **THEN** the DeepSeek completion request MUST include `reasoning_effort` with value `high`
+
+#### Scenario: Preserve disabled thinking configuration
+- **WHEN** the DeepSeek provider is configured with `EXTRA_BODY={"thinking":{"type":"disabled"}}`
+- **THEN** the DeepSeek completion request MUST preserve `thinking.type` as `disabled`
+
+### Requirement: DeepSeek reasoning response handling
+YAICLI SHALL expose DeepSeek `reasoning_content` responses through its internal reasoning stream.
+
+#### Scenario: Non-streaming reasoning content
+- **WHEN** a DeepSeek non-streaming response message contains `reasoning_content`
+- **THEN** YAICLI MUST emit an `LLMResponse` whose `reasoning` contains that value
+
+#### Scenario: Streaming reasoning content
+- **WHEN** a DeepSeek streaming delta contains `reasoning_content`
+- **THEN** YAICLI MUST emit an `LLMResponse` chunk whose `reasoning` contains that delta value
+
+### Requirement: DeepSeek reasoning replay
+YAICLI SHALL serialize stored assistant reasoning as DeepSeek `reasoning_content` when sending conversation history to DeepSeek.
+
+#### Scenario: Assistant reasoning without tool calls
+- **WHEN** a stored assistant message has `reasoning` and no tool calls
+- **THEN** the DeepSeek message payload MUST contain `reasoning_content`
+- **AND** the DeepSeek message payload MUST NOT contain the generic `reasoning` field
+
+#### Scenario: Assistant reasoning with tool calls
+- **WHEN** a stored assistant message has `reasoning` and one or more tool calls
+- **THEN** the DeepSeek message payload MUST contain `reasoning_content`
+- **AND** the DeepSeek message payload MUST preserve the assistant `tool_calls`
+- **AND** the DeepSeek message payload MUST NOT contain the generic `reasoning` field
+
+#### Scenario: Tool response replay
+- **WHEN** a stored tool response references a DeepSeek assistant tool call by `tool_call_id`
+- **THEN** the DeepSeek message payload MUST preserve that `tool_call_id`
+
+### Requirement: Provider-scoped compatibility
+YAICLI SHALL implement DeepSeek thinking replay without changing the message format of unrelated providers.
+
+#### Scenario: Generic OpenAI-compatible providers
+- **WHEN** a non-DeepSeek OpenAI-format provider converts an assistant message with `reasoning`
+- **THEN** its existing provider-specific reasoning field behavior MUST remain unchanged

--- a/tests/llms/test_deepseek_provider.py
+++ b/tests/llms/test_deepseek_provider.py
@@ -1,0 +1,163 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from yaicli.llms.providers.deepseek_provider import DeepSeekProvider
+from yaicli.schemas import ChatMessage, ToolCall
+
+
+class TestDeepSeekProvider:
+    """Tests for DeepSeek thinking mode compatibility."""
+
+    @pytest.fixture
+    def mock_config(self):
+        return {
+            "API_KEY": "fake_api_key",
+            "BASE_URL": "",
+            "MODEL": "deepseek-v4-pro",
+            "TEMPERATURE": 0.3,
+            "FREQUENCY_PENALTY": 0.0,
+            "TOP_P": 1.0,
+            "MAX_TOKENS": 1024,
+            "TIMEOUT": 60,
+            "EXTRA_HEADERS": None,
+            "EXTRA_BODY": {},
+            "REASONING_EFFORT": None,
+            "ENABLE_FUNCTIONS": False,
+            "ENABLE_MCP": False,
+        }
+
+    @pytest.fixture
+    def provider(self, mock_config):
+        with patch.object(DeepSeekProvider, "CLIENT_CLS"):
+            return DeepSeekProvider(config=mock_config)
+
+    @pytest.fixture
+    def mock_client(self):
+        chat_mock = MagicMock()
+        completions_mock = MagicMock()
+        completions_mock.create = MagicMock()
+        chat_mock.completions = completions_mock
+
+        client_mock = MagicMock()
+        client_mock.chat = chat_mock
+        return client_mock
+
+    def _mock_response(self, content="OK", reasoning_content=None, finish_reason="stop"):
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_message = MagicMock()
+        mock_message.content = content
+        mock_message.reasoning_content = reasoning_content
+        mock_message.model_extra = None
+        mock_message.tool_calls = None
+        mock_choice.message = mock_message
+        mock_choice.finish_reason = finish_reason
+        mock_response.choices = [mock_choice]
+        return mock_response
+
+    def test_completion_forwards_enabled_thinking_extra_body(self, mock_config, mock_client):
+        mock_config["EXTRA_BODY"] = {"thinking": {"type": "enabled"}}
+
+        with patch.object(DeepSeekProvider, "CLIENT_CLS"):
+            provider = DeepSeekProvider(config=mock_config)
+        provider.client = mock_client
+        mock_client.chat.completions.create.return_value = self._mock_response()
+
+        list(provider.completion([ChatMessage(role="user", content="Hello")]))
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["extra_body"] == {"thinking": {"type": "enabled"}}
+
+    def test_completion_preserves_disabled_thinking_extra_body(self, mock_config, mock_client):
+        mock_config["EXTRA_BODY"] = {"thinking": {"type": "disabled"}}
+
+        with patch.object(DeepSeekProvider, "CLIENT_CLS"):
+            provider = DeepSeekProvider(config=mock_config)
+        provider.client = mock_client
+        mock_client.chat.completions.create.return_value = self._mock_response()
+
+        list(provider.completion([ChatMessage(role="user", content="Hello")]))
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
+
+    def test_completion_forwards_reasoning_effort(self, mock_config, mock_client):
+        mock_config["REASONING_EFFORT"] = "high"
+
+        with patch.object(DeepSeekProvider, "CLIENT_CLS"):
+            provider = DeepSeekProvider(config=mock_config)
+        provider.client = mock_client
+        mock_client.chat.completions.create.return_value = self._mock_response()
+
+        list(provider.completion([ChatMessage(role="user", content="Hello")]))
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["reasoning_effort"] == "high"
+
+    def test_convert_messages_uses_reasoning_content_for_assistant_reasoning(self, provider):
+        messages = [ChatMessage(role="assistant", content="Final answer", reasoning="Thinking content")]
+
+        converted = provider._convert_messages(messages)
+
+        assert converted == [{"role": "assistant", "content": "Final answer", "reasoning_content": "Thinking content"}]
+
+    def test_convert_messages_preserves_tool_calls_with_reasoning_content(self, provider):
+        tool_call = ToolCall(id="call_123", name="get_weather", arguments='{"city": "Beijing"}')
+        messages = [
+            ChatMessage(
+                role="assistant",
+                content="Let me check",
+                reasoning="I need weather data",
+                tool_calls=[tool_call],
+            )
+        ]
+
+        converted = provider._convert_messages(messages)
+
+        assert converted[0]["reasoning_content"] == "I need weather data"
+        assert "reasoning" not in converted[0]
+        assert converted[0]["tool_calls"] == [
+            {
+                "id": "call_123",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": '{"city": "Beijing"}'},
+            }
+        ]
+
+    def test_convert_messages_preserves_tool_response_call_id(self, provider):
+        messages = [
+            ChatMessage(role="tool", content="Cloudy", name="get_weather", tool_call_id="call_123"),
+        ]
+
+        converted = provider._convert_messages(messages)
+
+        assert converted == [
+            {"role": "tool", "content": "Cloudy", "name": "get_weather", "tool_call_id": "call_123"}
+        ]
+
+    def test_completion_maps_reasoning_content_to_reasoning(self, provider, mock_client):
+        provider.client = mock_client
+        mock_client.chat.completions.create.return_value = self._mock_response(
+            content="Final answer",
+            reasoning_content="Thinking content",
+        )
+
+        responses = list(provider.completion([ChatMessage(role="user", content="Question")]))
+
+        assert responses[0].reasoning == "Thinking content"
+
+    def test_stream_completion_maps_reasoning_content_to_reasoning(self, provider, mock_client):
+        provider.client = mock_client
+        chunk = MagicMock()
+        chunk.choices = [MagicMock()]
+        chunk.choices[0].delta = MagicMock()
+        chunk.choices[0].delta.content = ""
+        chunk.choices[0].delta.model_extra = {"reasoning_content": "Thinking chunk"}
+        chunk.choices[0].delta.tool_calls = None
+        chunk.choices[0].finish_reason = None
+        mock_client.chat.completions.create.return_value = [chunk]
+
+        responses = list(provider.completion([ChatMessage(role="user", content="Question")], stream=True))
+
+        assert responses[0].reasoning == "Thinking chunk"

--- a/uv.lock
+++ b/uv.lock
@@ -2873,7 +2873,7 @@ wheels = [
 
 [[package]]
 name = "yaicli"
-version = "0.15.0"
+version = "0.15.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic", extra = ["bedrock", "vertex"] },

--- a/yaicli/llms/providers/deepseek_provider.py
+++ b/yaicli/llms/providers/deepseek_provider.py
@@ -1,3 +1,6 @@
+from typing import Any, Dict, List
+
+from ...schemas import ChatMessage
 from .openai_provider import OpenAIProvider
 
 
@@ -13,4 +16,14 @@ class DeepSeekProvider(OpenAIProvider):
         "max_tokens": "MAX_TOKENS",
         "timeout": "TIMEOUT",
         "extra_body": "EXTRA_BODY",
+        "reasoning_effort": "REASONING_EFFORT",
     }
+
+    def _convert_messages(self, messages: List[ChatMessage]) -> List[Dict[str, Any]]:
+        """Convert messages using DeepSeek's reasoning_content field."""
+        converted_messages = super()._convert_messages(messages)
+        for source, message in zip(messages, converted_messages):
+            if source.role == "assistant" and source.reasoning:
+                message.pop("reasoning", None)
+                message["reasoning_content"] = source.reasoning
+        return converted_messages


### PR DESCRIPTION
## Summary
- add DeepSeek reasoning_effort request support
- replay DeepSeek assistant reasoning as reasoning_content
- document DeepSeek thinking mode in README and provider docs
- archive the OpenSpec change and add the main spec

## Tests
- uv run pytest tests/llms/test_deepseek_provider.py tests/llms/test_openai_provider.py
- uv run ruff check yaicli/llms/providers/deepseek_provider.py tests/llms/test_deepseek_provider.py
- openspec validate deepseek-thinking-mode