### PR TITLE
feat!: confirm tool calls before execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 
 ---
+## [Unreleased]
+
+### ⛰️  Features
+
+- feat!: confirm tool/function calls before execution — allow once, allow for the session, allow permanently, or deny. **BREAKING:** tool calls now require confirmation by default; set `TOOL_CONFIRM=false` (env `YAI_TOOL_CONFIRM=false`) to restore the previous silent execution. Permanent approvals are stored per tool name in `~/.config/yaicli/tool_permissions.json`.
+
+
+---
 ## [0.16.0](https://github.com/belingud/yaicli/compare/v0.15.2..v0.16.0) - 2026-05-10
 
 ### ⛰️  Features

--- a/README.md
+++ b/README.md
@@ -203,6 +203,13 @@ The default configuration file is located at `~/.config/yaicli/config.ini`. You 
 | `ENABLE_MCP`           | Enable MCP tools                            | `false`                  | `YAI_ENABLE_MCP`           |
 | `SHOW_MCP_OUTPUT`      | Show MCP output when calling mcp            | `true`                   | `YAI_SHOW_MCP_OUTPUT`      |
 | `MAX_TOOL_CALL_DEPTH`  | Max tool calls in one request               | `8`                      | `YAI_MAX_TOOL_CALL_DEPTH`  |
+| `TOOL_CONFIRM`         | Confirm each tool call before running it    | `true`                   | `YAI_TOOL_CONFIRM`         |
+
+> **Tool execution confirmation:** With `TOOL_CONFIRM` enabled (the default), YAICLI asks before running each
+> tool/function call. At the prompt you can allow it once, allow it for the rest of the session, allow it permanently,
+> or deny it. Permanent approvals are stored per tool name in `~/.config/yaicli/tool_permissions.json`. Set
+> `TOOL_CONFIRM=false` (or `YAI_TOOL_CONFIRM=false`) to run tool calls silently, as in previous versions. In
+> non-interactive sessions (e.g. piped input) only tools already in the permissions file run; others are denied.
 
 ### LLM Provider Configuration
 

--- a/openspec/changes/archive/2026-06-14-add-tool-confirmation/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-14-add-tool-confirmation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-13

--- a/openspec/changes/archive/2026-06-14-add-tool-confirmation/design.md
+++ b/openspec/changes/archive/2026-06-14-add-tool-confirmation/design.md
@@ -1,0 +1,71 @@
+## Context
+
+YAICLI executes every model-requested tool call immediately and silently. All providers (OpenAI, Anthropic, Gemini, etc.) funnel tool execution through a single chokepoint: `execute_tool_call()` in `yaicli/tools/__init__.py`, invoked from the loop in `LLMClient._execute_tools_and_continue()` (`yaicli/llms/client.py`). Gemini does not bypass this — it disables the SDK's automatic function calling and yields `ToolCall` objects like the other providers, so a single gate covers every provider.
+
+The tool-execution loop runs inside a generator that `Printer.display_stream()` drives while a Rich `Live` region is active. Reading stdin for a confirmation prompt while `Live` is refreshing corrupts the terminal, so prompting requires coordinating with the live display. The existing `RefreshLive` control signal already models live-control as a value yielded out of the generator, which this change follows. (A sibling `StopLive` class is defined but unused; it is left as-is, since the pump stops the live region directly via `_safe_stop_live`.)
+
+Tool availability is already filtered upstream by `interactive-tool-policy` (`_get_valid_tool_calls`). Confirmation layers on top: only already-permitted calls reach the gate. `exec` mode disables all tools, so it is unaffected.
+
+Configuration is a flat `config.ini` under `[core]` with env (`YAI_*`) overrides; there is no config write-back API, and `config.ini` carries hand-written comments that `configparser.write()` would strip.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Confirm each tool call before execution, with outcomes: once, session, persistent-allow, deny.
+- Default to confirmation on, with a master switch (`TOOL_CONFIRM`) to restore silent execution.
+- Persist per-tool approvals across runs without disturbing `config.ini`.
+- Keep the feature provider-agnostic by gating at the single execution chokepoint.
+- Behave safely and non-blocking in non-interactive sessions.
+
+**Non-Goals:**
+- Batch "approve all" for a multi-call turn (each call is confirmed independently).
+- Argument-level confirmation or editing arguments before execution.
+- A permissions management TUI / slash command (the JSON file is hand-editable for now).
+- Changing `exec` mode's existing command confirmation.
+
+## Decisions
+
+### Gate location: the tool-execution loop, not `execute_tool_call()`
+The confirmation gate lives in `LLMClient._execute_tools_and_continue()`, just before each `execute_tool_call()`. The loop is a method with access to instance state (the approval manager), whereas `execute_tool_call()` is a module-level pure function. This keeps execution mechanism separate from approval policy. There is exactly one call site today, so coverage is complete.
+
+### Signal-based prompt coordination (chosen) over an injected callback
+The generator yields a new `ConfirmToolCall(tool_call)` signal; `display_stream()` receives it, stops the live region, renders the call, prompts, and resumes the generator via `gen.send(decision)`. `yield from` transparently forwards the sent value through the delegation chain to `_execute_tools_and_continue()`.
+
+- *Alternative considered*: inject a `confirmer` callback into `LLMClient` and have it reach into the printer to pause the live. Rejected because the callback would run re-entrantly inside `next(gen)` while the printer's loop frame is suspended, and it couples the client to live-display internals.
+- *Why signal wins*: `display_normal()` is dead code, so `display_stream()` is the only consumer to update; when the signal surfaces, control is back in the printer's own frame with the generator cleanly suspended at the `yield`, so stopping/restarting `Live` has no re-entrancy. It also matches the existing `RefreshLive` control-signal idiom.
+
+### Persistent approvals in a dedicated JSON file
+"Always allow" is written to `~/.config/yaicli/tool_permissions.json` (a tool-name allowlist), not `config.ini`. `configparser.write()` would strip the file's comments, and there is no existing write-back path. A dedicated file matches the project's convention of separate `mcp.json` and `roles/`. Writes use a temp-file + atomic rename so a crash mid-write cannot corrupt the list.
+
+### Per-tool-name granularity, keyed at the gate
+Approvals are keyed by tool name. The key is captured at the gate, where MCP names still carry their `_mcp__` prefix — `execute_tool_call()` strips that prefix in place at execution time, so recording later would lose it and could collide an MCP tool with a same-named built-in function. The global escape hatch is `TOOL_CONFIRM=false` rather than a separate "allow all" entry.
+
+### Default on, with a master switch
+`TOOL_CONFIRM` (env `YAI_TOOL_CONFIRM`, type bool) defaults to `true`. This is a behavior change for existing users; `TOOL_CONFIRM=false` restores prior silent execution. Registered in `DEFAULT_CONFIG_MAP`, so the default applies even for config files that predate the key.
+
+### Deny returns a matched tool result
+Denial does not raise; it appends a tool result message whose `tool_call_id` matches the denied call, stating the user declined. OpenAI-style providers require every `tool_call` in an assistant turn to have a matching tool result, so skipping would 400 the next request. This also lets the model adapt to the refusal.
+
+### Non-interactive policy
+When `sys.stdin.isatty()` is false (piped stdin / no TTY), the gate does not block: allowlisted tools execute, all others are denied with a hint to pre-approve or set `TOOL_CONFIRM=false`.
+
+## Risks / Trade-offs
+
+- **Breaking default (silent → confirm)** → Mitigation: `TOOL_CONFIRM=false` master switch; call out in CHANGELOG; the change is marked BREAKING in the proposal.
+- **`display_stream` pump rewrite (for-loop → next/send)** → Mitigation: single consumer; cover with tests for the signal round-trip and live stop/restart.
+- **`display_normal` is dead code and would not honor confirmation if revived** → Mitigation: note in code; if a non-stream display path is reintroduced it must handle `ConfirmToolCall`.
+- **Multiple prompts in one multi-tool turn** → Accepted for v1; batch approval is a v2 non-goal.
+- **Concurrent processes writing the allowlist** → Atomic rename prevents corruption; last-writer-wins on the set is acceptable for an allowlist.
+- **Prompt interruption (Ctrl-C / EOF)** → Caught and treated as deny, mirroring `exec` mode's `_confirm_and_execute` EOF handling, so it never propagates as an unhandled error.
+- **Duplicate call display** → `execute_tool_call()` already prints `@Function call: ...`; the confirmation prompt shows the same call, so one of the two must be suppressed when the gate prompts.
+
+## Migration Plan
+
+- Ship with `TOOL_CONFIRM=true`. Document in CHANGELOG that tool calls now require confirmation and how to opt out.
+- `tool_permissions.json` is created lazily (empty allowlist) on first persistent approval; absence means "nothing pre-approved".
+- Rollback for a user is `TOOL_CONFIRM=false`; rollback for the project is reverting the change (no persisted state migration needed).
+
+## Open Questions
+
+- Should a later version add a management command (e.g., `/tools` or `--reset-permissions`) to list/revoke persistent approvals? Deferred; the JSON file is hand-editable in v1.
+- Should there be an explicit global "allow all tools" allowlist entry in addition to the master switch? Deferred in favor of `TOOL_CONFIRM=false`.

--- a/openspec/changes/archive/2026-06-14-add-tool-confirmation/proposal.md
+++ b/openspec/changes/archive/2026-06-14-add-tool-confirmation/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Today YAICLI executes every model-requested tool call silently and immediately. A model can run shell commands, MCP tools, or other side-effecting functions without the user getting a chance to review or stop them. Users need the same per-call control that tools like Claude Code provide: confirm a call once, stop being asked for a tool this session, or permanently allow a tool — and be able to refuse.
+
+## What Changes
+
+- Add an execution-confirmation gate that runs after tool-availability filtering and before each tool call is executed.
+- Present a four-way prompt for any tool that is not already approved:
+  - **once** — execute this call only;
+  - **session** — execute and stop asking for this tool name for the rest of the process;
+  - **always** — execute and persist approval for this tool name across runs;
+  - **deny** — do not execute; return a refusal result to the model so the conversation continues.
+- Persist "always allow" decisions to a dedicated file `~/.config/yaicli/tool_permissions.json` (a tool-name allowlist), independent of `config.ini`.
+- Add a master switch `TOOL_CONFIRM` (env `YAI_TOOL_CONFIRM`), **default `true`**. **BREAKING**: tool calls now require confirmation by default; setting `TOOL_CONFIRM=false` restores the previous silent-execution behavior.
+- Define non-interactive behavior (no TTY / piped stdin): tools on the persistent allowlist run; all others are denied with a hint to pre-approve or disable confirmation.
+- Key the allowlist by the tool name as seen at the gate (MCP names keep their `_mcp__` prefix) so MCP tools and same-named built-in functions never collide.
+
+## Capabilities
+
+### New Capabilities
+- `tool-execution-confirmation`: Per-call confirmation of tool execution with once / session / persistent-allow / deny outcomes, a master enable switch, a persisted per-tool allowlist, and defined non-interactive behavior.
+
+### Modified Capabilities
+- `interactive-tool-policy`: An allowed tool call no longer executes unconditionally — it proceeds to execution subject to the execution-confirmation policy. The "allowed tool call continues normal execution" behavior is refined to account for the confirmation gate.
+
+## Impact
+
+- **Behavior**: Tool calls require confirmation by default in interactive sessions; existing users relying on silent function execution must set `TOOL_CONFIRM=false` or pre-approve tools.
+- **Code**: `yaicli/schemas.py` (new control signal, decision type), `yaicli/llms/client.py` (confirmation gate in the tool-execution loop), `yaicli/printer.py` (stream pump handles the confirmation signal and pauses the live display), `yaicli/cli.py` (wires the approval manager and non-interactive policy), `yaicli/const.py` (new config key and permissions path), and a new `yaicli/tools/approval.py`.
+- **Files/Config**: New `~/.config/yaicli/tool_permissions.json`; new `TOOL_CONFIRM` config key.
+- **Providers**: Provider-agnostic — all providers funnel tool execution through a single chokepoint, so no per-provider changes are required.

--- a/openspec/changes/archive/2026-06-14-add-tool-confirmation/specs/interactive-tool-policy/spec.md
+++ b/openspec/changes/archive/2026-06-14-add-tool-confirmation/specs/interactive-tool-policy/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Disabled tool calls are ignored and not persisted
+If a provider returns a tool call that is not permitted for the current request, the system SHALL ignore that tool call. The system SHALL NOT execute it, and it SHALL NOT persist the disallowed tool call in assistant history for later turns. A tool call that IS permitted for the current request SHALL proceed to the execution-confirmation policy, which decides whether it executes, rather than executing unconditionally.
+
+#### Scenario: Disallowed function tool call is dropped
+- **WHEN** an interactive request is made with built-in function tools disabled and the provider returns a built-in function tool call
+- **THEN** the system SHALL not execute the tool call and SHALL store the assistant turn without that tool call in conversation history
+
+#### Scenario: Disallowed MCP tool call is dropped
+- **WHEN** an interactive request is made with MCP tools disabled and the provider returns an MCP tool call
+- **THEN** the system SHALL not execute the MCP tool call and SHALL store the assistant turn without that tool call in conversation history
+
+#### Scenario: Allowed tool call continues to the confirmation policy
+- **WHEN** an interactive request is made with a tool type enabled and the provider returns a tool call of that enabled type
+- **THEN** the system SHALL pass the tool call to the execution-confirmation policy, which determines whether it executes, and SHALL continue the conversation with the resulting tool result

--- a/openspec/changes/archive/2026-06-14-add-tool-confirmation/specs/tool-execution-confirmation/spec.md
+++ b/openspec/changes/archive/2026-06-14-add-tool-confirmation/specs/tool-execution-confirmation/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Tool execution requires confirmation by default
+
+When tool-execution confirmation is enabled, the system SHALL prompt the user to approve a tool call before executing it, unless the tool has already been approved for the current session or in the persistent allowlist. Confirmation SHALL be governed by a `TOOL_CONFIRM` setting (environment variable `YAI_TOOL_CONFIRM`) that defaults to enabled. The confirmation gate SHALL run after tool-availability filtering, so only tool calls already permitted for the request can reach it.
+
+#### Scenario: First call to an unapproved tool prompts the user
+- **WHEN** confirmation is enabled and the model returns a permitted tool call for a tool that is not in the session or persistent allowlist
+- **THEN** the system SHALL prompt the user to approve the call before executing it
+
+#### Scenario: Master switch disables confirmation
+- **WHEN** `TOOL_CONFIRM` is disabled and the model returns a permitted tool call
+- **THEN** the system SHALL execute the tool call without prompting, matching the prior silent-execution behavior
+
+### Requirement: Confirmation offers once, session, persistent, and deny outcomes
+
+The confirmation prompt SHALL offer four outcomes: execute only the current call (once), execute and stop asking for this tool name for the remainder of the process (session), execute and persist approval for this tool name across runs (persistent), and refuse the call (deny).
+
+#### Scenario: Approve once executes only the current call
+- **WHEN** the user approves a tool call for the current call only
+- **THEN** the system SHALL execute that call and SHALL prompt again the next time the same tool is called
+
+#### Scenario: Approve for session suppresses later prompts
+- **WHEN** the user approves a tool for the session and the same tool is called again later in the same process
+- **THEN** the system SHALL execute the later call without prompting
+
+#### Scenario: Deny does not execute the tool
+- **WHEN** the user denies a tool call
+- **THEN** the system SHALL NOT execute the tool
+
+### Requirement: Persistent approval survives across runs
+
+When the user grants persistent approval for a tool, the system SHALL record the tool name in a persistent allowlist stored at `~/.config/yaicli/tool_permissions.json`, written so a partial write cannot corrupt the existing file. On a later run, a tool present in the persistent allowlist SHALL execute without prompting.
+
+#### Scenario: Persistent approval is recorded
+- **WHEN** the user grants persistent approval for a tool
+- **THEN** the tool name SHALL be added to the persistent allowlist file
+
+#### Scenario: A new run honors the persistent allowlist
+- **WHEN** a new process starts with a tool already present in the persistent allowlist and that tool is called
+- **THEN** the system SHALL execute the call without prompting
+
+### Requirement: Denied tool calls return a refusal result to the model
+
+When a tool call is denied, the system SHALL NOT execute the tool and SHALL append a tool result message whose tool-call identifier matches the denied call, indicating the user declined execution, so the conversation can continue and the provider request remains valid.
+
+#### Scenario: Deny appends a matched refusal result
+- **WHEN** a tool call is denied
+- **THEN** the system SHALL append a tool result for that call's identifier stating the user declined, and SHALL continue the conversation
+
+#### Scenario: Multi-call turn with a denial stays valid
+- **WHEN** the model returns multiple tool calls in one turn and at least one is denied
+- **THEN** every tool call in the turn SHALL have a corresponding tool result message before the next provider request
+
+### Requirement: Non-interactive sessions do not block on prompts
+
+When confirmation is enabled but the session is non-interactive (no controlling TTY, such as piped stdin), the system SHALL NOT block waiting for input. Tools present in the persistent allowlist SHALL execute; all other tools SHALL be denied, and the system SHALL surface a hint to pre-approve the tool or disable confirmation.
+
+#### Scenario: Allowlisted tool runs without a TTY
+- **WHEN** the session is non-interactive and a called tool is in the persistent allowlist
+- **THEN** the system SHALL execute the tool without prompting
+
+#### Scenario: Non-allowlisted tool is denied without a TTY
+- **WHEN** the session is non-interactive and a called tool is not in the persistent allowlist
+- **THEN** the system SHALL deny the call and surface a hint to pre-approve it or disable confirmation
+
+### Requirement: Approval is keyed by tool name with MCP prefix preserved
+
+The system SHALL key session and persistent approvals by the tool name as observed at the confirmation gate. MCP tool names SHALL retain their MCP prefix so that an MCP tool and a built-in function sharing the same base name are tracked as distinct approvals.
+
+#### Scenario: MCP tool and same-named function are distinct
+- **WHEN** a built-in function and an MCP tool resolve to the same base name and one of them is approved
+- **THEN** approving one SHALL NOT suppress the confirmation prompt for the other
+
+### Requirement: Interrupting the prompt cancels the call
+
+When the user interrupts the confirmation prompt (for example via Ctrl-C or end-of-input), the system SHALL treat the interruption as a denial of the current call rather than allowing an unhandled error to propagate.
+
+#### Scenario: Interrupt at the prompt denies the call
+- **WHEN** the user interrupts the confirmation prompt for a tool call
+- **THEN** the system SHALL treat the call as denied and continue without executing the tool

--- a/openspec/changes/archive/2026-06-14-add-tool-confirmation/tasks.md
+++ b/openspec/changes/archive/2026-06-14-add-tool-confirmation/tasks.md
@@ -1,0 +1,58 @@
+## 1. Config & constants
+
+- [x] 1.1 Register `TOOL_CONFIRM` in `DEFAULT_CONFIG_MAP` (`yaicli/const.py`): default `"true"`, env `YAI_TOOL_CONFIRM`, type `bool`; add a `DEFAULT_TOOL_CONFIRM` default constant alongside the others.
+- [x] 1.2 Add `TOOL_PERMISSIONS_PATH = CONFIG_PATH.parent / "tool_permissions.json"` to `yaicli/const.py`.
+- [x] 1.3 Add the `TOOL_CONFIRM` line (with an explanatory comment) to `DEFAULT_CONFIG_INI` so new config files document it.
+
+## 2. Schemas (control signal & decision type)
+
+- [x] 2.1 In `yaicli/schemas.py`, add a `ToolConfirmDecision` type covering `once`, `session`, `persist`, `deny` (StrEnum or constants).
+- [x] 2.2 Add `@dataclass ConfirmToolCall` carrying the `ToolCall` to be confirmed.
+- [x] 2.3 Confirm `StopLive` is used by the printer pump (it is currently defined but unused); keep or wire it in step 5. (Kept as-is: the pump stops the live region directly via `_safe_stop_live`, so a routed StopLive signal is unnecessary.)
+
+## 3. Approval manager (new module)
+
+- [x] 3.1 Create `yaicli/tools/approval.py` with `ToolApprovalManager` holding `session_allow: set[str]` and `persistent_allow: set[str]`.
+- [x] 3.2 Load `persistent_allow` from `TOOL_PERMISSIONS_PATH` on init; tolerate a missing or malformed file (treat as empty).
+- [x] 3.3 Implement `is_allowed(name)` returning membership in the union of session and persistent sets.
+- [x] 3.4 Implement `allow_session(name)` (in-memory only) and `allow_persist(name)` (update set + write file).
+- [x] 3.5 Persist with a temp-file + atomic `os.replace` write so a partial write cannot corrupt the allowlist; create parent dir if needed. (Write happens before the in-memory set is updated, so a failed write leaves both intact.)
+
+## 4. Confirmation gate in the client
+
+- [x] 4.1 Extend `LLMClient.__init__` to accept and store an `approval` manager and an `interactive: bool` flag.
+- [x] 4.2 In `_execute_tools_and_continue`, before each `execute_tool_call`, capture the gate-time tool name (MCP names keep the `_mcp__` prefix) and resolve a decision: execute when `TOOL_CONFIRM` is off or `approval.is_allowed(name)`; deny (no prompt) when not interactive; otherwise `decision = yield ConfirmToolCall(tc)`.
+- [x] 4.3 After an interactive decision, record `session`/`persist` outcomes via the approval manager keyed by the gate-time name. (Persist failure degrades gracefully to session approval with a warning.)
+- [x] 4.4 On deny, skip execution and append a `tool`-role message whose `tool_call_id` matches the denied call, stating the user declined; ensure every tool call in the turn still produces a matching result message.
+- [x] 4.5 On non-interactive deny, print a hint to pre-approve the tool or set `TOOL_CONFIRM=false`.
+
+## 5. Printer prompt & stream pump
+
+- [x] 5.1 Rework `Printer.display_stream` to drive the generator with `next`/`send` instead of a plain `for`, preserving existing `RefreshLive` and `LLMResponse` handling.
+- [x] 5.2 On receiving `ConfirmToolCall`, stop the active `Live` (`_safe_stop_live`), render the pending call (name + arguments), and prompt with `[y]once / [a]session / [A]persist / [n]deny`.
+- [x] 5.3 Map the keypress to a `ToolConfirmDecision` and resume the generator via `gen.send(decision)`; restart/realign the `Live` so subsequent streaming renders correctly.
+- [x] 5.4 Catch `KeyboardInterrupt`/`EOFError` at the prompt and send a `deny` decision (mirroring `exec` mode's EOF handling) so it never propagates as an unhandled error.
+
+## 6. CLI wiring & non-interactive policy
+
+- [x] 6.1 In `yaicli/cli.py`, construct a `ToolApprovalManager` and pass it (plus `interactive=sys.stdin.isatty()`) into the `LLMClient` at `_create_client`.
+
+## 7. Display de-duplication
+
+- [x] 7.1 Avoid double-printing the call: `execute_tool_call` takes an `announce` flag, and the client passes `announce=False` when the gate already showed the call via the prompt.
+
+## 8. Tests
+
+- [x] 8.1 `once`: approving once executes; the tool is not remembered (`is_allowed` stays False).
+- [x] 8.2 `session`: after session approval, a later call to the same tool executes without prompting.
+- [x] 8.3 `persist`: persistent approval writes the tool to `tool_permissions.json`; a fresh `ToolApprovalManager` loaded from that file executes without prompting.
+- [x] 8.4 `deny`: a denied call appends a `tool` result with the matching `tool_call_id` and the conversation continues; multi-call turns leave no tool call without a result.
+- [x] 8.5 Non-interactive: with no TTY, an allowlisted tool runs and a non-allowlisted tool is denied.
+- [x] 8.6 Master switch: `TOOL_CONFIRM=false` executes all tool calls without prompting.
+- [x] 8.7 MCP keying: an MCP tool (prefixed name) and a same-named built-in function are tracked as distinct approvals.
+- [x] 8.8 Atomic write: a simulated write failure leaves the prior `tool_permissions.json` intact.
+
+## 9. Docs
+
+- [x] 9.1 Update `CHANGELOG` noting the **BREAKING** default-on confirmation and the `TOOL_CONFIRM=false` opt-out. (Added an Unreleased section; the breaking marker should also ride the commit message for the changelog generator.)
+- [x] 9.2 Document `TOOL_CONFIRM` and `tool_permissions.json` in the README/config reference.

--- a/openspec/specs/interactive-tool-policy/spec.md
+++ b/openspec/specs/interactive-tool-policy/spec.md
@@ -38,7 +38,7 @@ Switching between interactive modes SHALL affect only the effective tool availab
 - **THEN** the later `chat` mode request SHALL continue to advertise no tools
 
 ### Requirement: Disabled tool calls are ignored and not persisted
-If a provider returns a tool call that is not permitted for the current request, the system SHALL ignore that tool call. The system SHALL NOT execute it, and it SHALL NOT persist the disallowed tool call in assistant history for later turns.
+If a provider returns a tool call that is not permitted for the current request, the system SHALL ignore that tool call. The system SHALL NOT execute it, and it SHALL NOT persist the disallowed tool call in assistant history for later turns. A tool call that IS permitted for the current request SHALL proceed to the execution-confirmation policy, which decides whether it executes, rather than executing unconditionally.
 
 #### Scenario: Disallowed function tool call is dropped
 - **WHEN** an interactive request is made with built-in function tools disabled and the provider returns a built-in function tool call
@@ -48,6 +48,6 @@ If a provider returns a tool call that is not permitted for the current request,
 - **WHEN** an interactive request is made with MCP tools disabled and the provider returns an MCP tool call
 - **THEN** the system SHALL not execute the MCP tool call and SHALL store the assistant turn without that tool call in conversation history
 
-#### Scenario: Allowed tool call continues normal execution
+#### Scenario: Allowed tool call continues to the confirmation policy
 - **WHEN** an interactive request is made with a tool type enabled and the provider returns a tool call of that enabled type
-- **THEN** the system SHALL execute the tool call and continue the conversation with the tool result
+- **THEN** the system SHALL pass the tool call to the execution-confirmation policy, which determines whether it executes, and SHALL continue the conversation with the resulting tool result

--- a/openspec/specs/tool-execution-confirmation/spec.md
+++ b/openspec/specs/tool-execution-confirmation/spec.md
@@ -1,0 +1,85 @@
+## Purpose
+
+Define how YAICLI confirms tool/function execution with the user before running each call, so that side-effecting tools require explicit approval. Approval can be granted once, for the session, or permanently, or refused; a master switch can disable confirmation, and non-interactive sessions behave safely without blocking.
+
+## Requirements
+
+### Requirement: Tool execution requires confirmation by default
+
+When tool-execution confirmation is enabled, the system SHALL prompt the user to approve a tool call before executing it, unless the tool has already been approved for the current session or in the persistent allowlist. Confirmation SHALL be governed by a `TOOL_CONFIRM` setting (environment variable `YAI_TOOL_CONFIRM`) that defaults to enabled. The confirmation gate SHALL run after tool-availability filtering, so only tool calls already permitted for the request can reach it.
+
+#### Scenario: First call to an unapproved tool prompts the user
+- **WHEN** confirmation is enabled and the model returns a permitted tool call for a tool that is not in the session or persistent allowlist
+- **THEN** the system SHALL prompt the user to approve the call before executing it
+
+#### Scenario: Master switch disables confirmation
+- **WHEN** `TOOL_CONFIRM` is disabled and the model returns a permitted tool call
+- **THEN** the system SHALL execute the tool call without prompting, matching the prior silent-execution behavior
+
+### Requirement: Confirmation offers once, session, persistent, and deny outcomes
+
+The confirmation prompt SHALL offer four outcomes: execute only the current call (once), execute and stop asking for this tool name for the remainder of the process (session), execute and persist approval for this tool name across runs (persistent), and refuse the call (deny).
+
+#### Scenario: Approve once executes only the current call
+- **WHEN** the user approves a tool call for the current call only
+- **THEN** the system SHALL execute that call and SHALL prompt again the next time the same tool is called
+
+#### Scenario: Approve for session suppresses later prompts
+- **WHEN** the user approves a tool for the session and the same tool is called again later in the same process
+- **THEN** the system SHALL execute the later call without prompting
+
+#### Scenario: Deny does not execute the tool
+- **WHEN** the user denies a tool call
+- **THEN** the system SHALL NOT execute the tool
+
+### Requirement: Persistent approval survives across runs
+
+When the user grants persistent approval for a tool, the system SHALL record the tool name in a persistent allowlist stored at `~/.config/yaicli/tool_permissions.json`, written so a partial write cannot corrupt the existing file. On a later run, a tool present in the persistent allowlist SHALL execute without prompting.
+
+#### Scenario: Persistent approval is recorded
+- **WHEN** the user grants persistent approval for a tool
+- **THEN** the tool name SHALL be added to the persistent allowlist file
+
+#### Scenario: A new run honors the persistent allowlist
+- **WHEN** a new process starts with a tool already present in the persistent allowlist and that tool is called
+- **THEN** the system SHALL execute the call without prompting
+
+### Requirement: Denied tool calls return a refusal result to the model
+
+When a tool call is denied, the system SHALL NOT execute the tool and SHALL append a tool result message whose tool-call identifier matches the denied call, indicating the user declined execution, so the conversation can continue and the provider request remains valid.
+
+#### Scenario: Deny appends a matched refusal result
+- **WHEN** a tool call is denied
+- **THEN** the system SHALL append a tool result for that call's identifier stating the user declined, and SHALL continue the conversation
+
+#### Scenario: Multi-call turn with a denial stays valid
+- **WHEN** the model returns multiple tool calls in one turn and at least one is denied
+- **THEN** every tool call in the turn SHALL have a corresponding tool result message before the next provider request
+
+### Requirement: Non-interactive sessions do not block on prompts
+
+When confirmation is enabled but the session is non-interactive (no controlling TTY, such as piped stdin), the system SHALL NOT block waiting for input. Tools present in the persistent allowlist SHALL execute; all other tools SHALL be denied, and the system SHALL surface a hint to pre-approve the tool or disable confirmation.
+
+#### Scenario: Allowlisted tool runs without a TTY
+- **WHEN** the session is non-interactive and a called tool is in the persistent allowlist
+- **THEN** the system SHALL execute the tool without prompting
+
+#### Scenario: Non-allowlisted tool is denied without a TTY
+- **WHEN** the session is non-interactive and a called tool is not in the persistent allowlist
+- **THEN** the system SHALL deny the call and surface a hint to pre-approve it or disable confirmation
+
+### Requirement: Approval is keyed by tool name with MCP prefix preserved
+
+The system SHALL key session and persistent approvals by the tool name as observed at the confirmation gate. MCP tool names SHALL retain their MCP prefix so that an MCP tool and a built-in function sharing the same base name are tracked as distinct approvals.
+
+#### Scenario: MCP tool and same-named function are distinct
+- **WHEN** a built-in function and an MCP tool resolve to the same base name and one of them is approved
+- **THEN** approving one SHALL NOT suppress the confirmation prompt for the other
+
+### Requirement: Interrupting the prompt cancels the call
+
+When the user interrupts the confirmation prompt (for example via Ctrl-C or end-of-input), the system SHALL treat the interruption as a denial of the current call rather than allowing an unhandled error to propagate.
+
+#### Scenario: Interrupt at the prompt denies the call
+- **WHEN** the user interrupts the confirmation prompt for a tool call
+- **THEN** the system SHALL treat the call as denied and continue without executing the tool

--- a/tests/llms/test_ai21_provider.py
+++ b/tests/llms/test_ai21_provider.py
@@ -112,3 +112,56 @@ class TestAI21Provider:
             assert responses[0].tool_call.id == "tc_123"
             assert responses[0].tool_call.name == "get_weather"
             assert responses[0].tool_call.arguments == '{"location": "New York"}'
+
+    def test_process_tool_call_chunk_first_chunk(self, mock_config):
+        """Test _process_tool_call_chunk when processing the first chunk"""
+        with patch("yaicli.llms.providers.openai_provider.openai.OpenAI"):
+            provider = AI21Provider(config=mock_config)
+
+            # Create mock tool call for first chunk
+            mock_tool = MagicMock()
+            mock_tool.id = "call_abc123"
+            mock_tool.function.name = "test_function"
+            mock_tool.function.arguments = "{}"
+
+            result = provider._process_tool_call_chunk([mock_tool], existing_tool_call=None)
+
+            assert result.id == "call_abc123"
+            assert result.name == "test_function"
+            assert result.arguments == "{}"
+
+    def test_process_tool_call_chunk_update_existing(self, mock_config):
+        """Test _process_tool_call_chunk when updating an existing tool call"""
+        with patch("yaicli.llms.providers.openai_provider.openai.OpenAI"):
+            provider = AI21Provider(config=mock_config)
+
+            # Create existing tool call
+            existing = ToolCall(id="call_abc123", name="test_function", arguments='{"key": "old"}')
+
+            # Create mock tool call with new arguments
+            mock_tool = MagicMock()
+            mock_tool.id = None  # Subsequent chunks typically don't repeat the id
+            mock_tool.function.name = None
+            mock_tool.function.arguments = '{"key": "new"}'
+
+            result = provider._process_tool_call_chunk([mock_tool], existing_tool_call=existing)
+
+            assert result.id == "call_abc123"
+            assert result.name == "test_function"
+            assert result.arguments == '{"key": "new"}'
+
+    def test_process_tool_call_chunk_empty_new_arguments(self, mock_config):
+        """Test _process_tool_call_chunk when new arguments are empty"""
+        with patch("yaicli.llms.providers.openai_provider.openai.OpenAI"):
+            provider = AI21Provider(config=mock_config)
+
+            existing = ToolCall(id="call_xyz", name="fn", arguments='{"existing": "data"}')
+
+            # Mock tool call with empty/missing arguments
+            mock_tool = MagicMock()
+            mock_tool.function.arguments = ""
+
+            result = provider._process_tool_call_chunk([mock_tool], existing_tool_call=existing)
+
+            # Should keep existing arguments when new ones are empty
+            assert result.arguments == '{"existing": "data"}'

--- a/tests/llms/test_anthropic_provider.py
+++ b/tests/llms/test_anthropic_provider.py
@@ -3,8 +3,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from yaicli.llms.providers.anthropic_provider import AnthropicProvider
-from yaicli.schemas import ChatMessage, ToolPolicy
+from yaicli.exceptions import ConfigMissingError, MCPToolsError
+from yaicli.llms.providers.anthropic_provider import (
+    AnthropicBedrockProvider,
+    AnthropicProvider,
+    AnthropicVertexProvider,
+)
+from yaicli.schemas import ChatMessage, ImageData, ToolPolicy
 
 
 class TestAnthropicProvider:
@@ -324,3 +329,326 @@ class TestAnthropicProvider:
             assert converted[2]["content"][0]["type"] == "tool_result"
             assert converted[2]["content"][0]["tool_use_id"] == "tool_1"
             assert converted[2]["content"][0]["content"] == "15 degrees"
+
+
+class TestAnthropicProviderCoverage:
+    """Additional tests covering uncovered branches in anthropic_provider."""
+
+    @pytest.fixture
+    def mock_config(self):
+        return {
+            "API_KEY": "fake_api_key",
+            "BASE_URL": "https://api.anthropic.com",
+            "MODEL": "claude-3-sonnet-20240229",
+            "TEMPERATURE": 0.7,
+            "TOP_P": 1.0,
+            "MAX_TOKENS": 1000,
+            "TIMEOUT": 60,
+            "EXTRA_HEADERS": None,
+            "EXTRA_BODY": None,
+            "ENABLE_FUNCTIONS": True,
+            "ENABLE_MCP": False,
+        }
+
+    def _make_text_response(self):
+        block = MagicMock()
+        block.type = "text"
+        block.text = "ok"
+        resp = MagicMock()
+        resp.content = [block]
+        resp.stop_reason = "stop"
+        return resp
+
+    def test_init_missing_api_key_raises(self, mock_config):
+        """__init__ raises ValueError when API_KEY is missing."""
+        mock_config["API_KEY"] = ""
+        with pytest.raises(ValueError, match="API_KEY is required"):
+            AnthropicProvider(config=mock_config)
+
+    def test_get_client_params_merges_extra_headers(self, mock_config):
+        """EXTRA_HEADERS are merged into default_headers, with timeout and base_url applied."""
+        mock_config["EXTRA_HEADERS"] = {"X-Custom": "abc"}
+        with patch.object(AnthropicProvider, "CLIENT_CLS", MagicMock()):
+            provider = AnthropicProvider(config=mock_config)
+        params = provider.get_client_params()
+        assert params["default_headers"]["X-Custom"] == "abc"
+        assert params["timeout"] == 60
+        assert params["base_url"] == "https://api.anthropic.com"
+
+    def test_completion_extracts_system_prompt(self, mock_config):
+        """System message is extracted into params['system'] and removed from messages."""
+        mock_config["ENABLE_FUNCTIONS"] = False
+        with patch.object(AnthropicProvider, "CLIENT_CLS", MagicMock()):
+            provider = AnthropicProvider(config=mock_config)
+            provider.client.messages.create.return_value = self._make_text_response()
+            messages = [
+                ChatMessage(role="system", content="You are helpful"),
+                ChatMessage(role="user", content="hi"),
+            ]
+            list(provider.completion(messages))
+
+        call_kwargs = provider.client.messages.create.call_args.kwargs
+        assert call_kwargs["system"] == "You are helpful"
+        roles = [m["role"] for m in call_kwargs["messages"]]
+        assert "system" not in roles
+
+    def test_completion_schemas_import_error(self, mock_config):
+        """ImportError while loading function schemas is caught and reported."""
+        with patch.object(AnthropicProvider, "CLIENT_CLS", MagicMock()):
+            provider = AnthropicProvider(config=mock_config)
+            provider.client.messages.create.return_value = self._make_text_response()
+            mock_console = MagicMock()
+            provider.console = mock_console
+            with patch("yaicli.tools.get_anthropic_schemas", side_effect=ImportError):
+                list(provider.completion([ChatMessage(role="user", content="hi")]))
+
+        printed = [str(c.args[0]) for c in mock_console.print.call_args_list]
+        assert any("Function tools not available" in t for t in printed)
+
+    def test_completion_with_mcp_tools(self, mock_config):
+        """MCP tools are appended when enable_mcp is set."""
+        mock_config["ENABLE_MCP"] = True
+        with patch.object(AnthropicProvider, "CLIENT_CLS", MagicMock()):
+            provider = AnthropicProvider(config=mock_config)
+            provider.client.messages.create.return_value = self._make_text_response()
+            with (
+                patch("yaicli.tools.get_anthropic_schemas", return_value=[{"name": "fn"}]),
+                patch("yaicli.tools.get_anthropic_mcp_tools", return_value=[{"name": "mcp_fn"}]),
+            ):
+                list(provider.completion([ChatMessage(role="user", content="hi")]))
+
+        call_kwargs = provider.client.messages.create.call_args.kwargs
+        tool_names = [t["name"] for t in call_kwargs["tools"]]
+        assert "mcp_fn" in tool_names
+
+    def test_completion_mcp_tools_error(self, mock_config):
+        """Errors loading MCP tools are caught and reported."""
+        mock_config["ENABLE_MCP"] = True
+        with patch.object(AnthropicProvider, "CLIENT_CLS", MagicMock()):
+            provider = AnthropicProvider(config=mock_config)
+            provider.client.messages.create.return_value = self._make_text_response()
+            mock_console = MagicMock()
+            provider.console = mock_console
+            with (
+                patch("yaicli.tools.get_anthropic_schemas", return_value=[]),
+                patch("yaicli.tools.get_anthropic_mcp_tools", side_effect=MCPToolsError("boom")),
+            ):
+                list(provider.completion([ChatMessage(role="user", content="hi")]))
+
+        printed = [str(c.args[0]) for c in mock_console.print.call_args_list]
+        assert any("Failed to load MCP tools" in t for t in printed)
+
+    def test_completion_verbose_prints(self, mock_config):
+        """verbose=True prints system prompt, messages, tools, tool choice and extra body."""
+        mock_config["EXTRA_BODY"] = {"foo": "bar"}
+        with patch.object(AnthropicProvider, "CLIENT_CLS", MagicMock()):
+            provider = AnthropicProvider(config=mock_config, verbose=True)
+            provider.client.messages.create.return_value = self._make_text_response()
+            mock_console = MagicMock()
+            provider.console = mock_console
+            with patch("yaicli.tools.get_anthropic_schemas", return_value=[{"name": "fn"}]):
+                messages = [
+                    ChatMessage(role="system", content="sys"),
+                    ChatMessage(role="user", content="hi"),
+                ]
+                list(provider.completion(messages))
+
+        printed = [str(c.args[0]) for c in mock_console.print.call_args_list]
+        assert any("System prompt:" in t for t in printed)
+        assert any("Tools:" in t for t in printed)
+        assert any("Extra body:" in t for t in printed)
+
+    def test_completion_api_error_raises(self, mock_config):
+        """API errors are printed and re-raised."""
+        mock_config["ENABLE_FUNCTIONS"] = False
+        with patch.object(AnthropicProvider, "CLIENT_CLS", MagicMock()):
+            provider = AnthropicProvider(config=mock_config)
+            provider.client.messages.create.side_effect = RuntimeError("api down")
+            mock_console = MagicMock()
+            provider.console = mock_console
+            with pytest.raises(RuntimeError, match="api down"):
+                list(provider.completion([ChatMessage(role="user", content="hi")]))
+
+        printed = [str(c.args[0]) for c in mock_console.print.call_args_list]
+        assert any("Error:" in t for t in printed)
+
+    def test_normal_response_empty_content(self, mock_config):
+        """_handle_normal_response yields a serialized dump when content is empty."""
+        with patch.object(AnthropicProvider, "CLIENT_CLS", MagicMock()):
+            provider = AnthropicProvider(config=mock_config)
+
+        resp = MagicMock()
+        resp.content = []
+        resp.model_dump.return_value = {"id": "msg_1"}
+        responses = list(provider._handle_normal_response(resp))
+
+        assert len(responses) == 1
+        assert responses[0].finish_reason == "stop"
+        assert "msg_1" in responses[0].content
+
+    def test_stream_tool_use_full_flow(self, mock_config):
+        """Streaming tool_use: message_start, block_start, partial_json deltas, stop, message_delta, message_stop."""
+        with patch.object(AnthropicProvider, "CLIENT_CLS", MagicMock()):
+            provider = AnthropicProvider(config=mock_config)
+
+        c_start = MagicMock()
+        c_start.type = "message_start"
+
+        c_block_start = MagicMock()
+        c_block_start.type = "content_block_start"
+        c_block_start.content_block.type = "tool_use"
+        c_block_start.content_block.id = "tool_1"
+        c_block_start.content_block.name = "get_weather"
+
+        c_delta1 = MagicMock()
+        c_delta1.type = "content_block_delta"
+        c_delta1.delta = MagicMock(spec=["partial_json"])
+        c_delta1.delta.partial_json = '{"location":'
+
+        c_delta2 = MagicMock()
+        c_delta2.type = "content_block_delta"
+        c_delta2.delta = MagicMock(spec=["partial_json"])
+        c_delta2.delta.partial_json = ' "NYC"}'
+
+        c_block_stop = MagicMock()
+        c_block_stop.type = "content_block_stop"
+
+        c_msg_delta = MagicMock()
+        c_msg_delta.type = "message_delta"
+        c_msg_delta.delta = MagicMock(spec=["stop_reason"])
+        c_msg_delta.delta.stop_reason = "tool_use"
+
+        c_msg_stop = MagicMock()
+        c_msg_stop.type = "message_stop"
+
+        chunks = [c_start, c_block_start, c_delta1, c_delta2, c_block_stop, c_msg_delta, c_msg_stop]
+        responses = list(provider._handle_stream_response(chunks))
+
+        tool_responses = [r for r in responses if r.tool_call is not None]
+        assert tool_responses
+        tc = tool_responses[0].tool_call
+        assert tc.id == "tool_1"
+        assert tc.name == "get_weather"
+        assert "NYC" in tc.arguments
+
+        reasons = [r.finish_reason for r in responses]
+        assert "tool_use" in reasons
+        assert "stop" in reasons
+
+    def test_convert_messages_with_images(self, mock_config):
+        """_convert_messages encodes url and base64 images plus a trailing text block."""
+        with patch.object(AnthropicProvider, "CLIENT_CLS", MagicMock()):
+            provider = AnthropicProvider(config=mock_config)
+
+        messages = [
+            ChatMessage(
+                role="user",
+                content="describe these",
+                images=[
+                    ImageData(data="https://example.com/a.png", media_type="image/png", is_url=True),
+                    ImageData(data="b64data", media_type="image/jpeg", is_url=False),
+                ],
+            )
+        ]
+        converted = provider._convert_messages(messages)
+
+        content = converted[0]["content"]
+        assert content[0] == {"type": "image", "source": {"type": "url", "url": "https://example.com/a.png"}}
+        assert content[1]["source"]["type"] == "base64"
+        assert content[1]["source"]["media_type"] == "image/jpeg"
+        assert content[1]["source"]["data"] == "b64data"
+        assert content[-1] == {"type": "text", "text": "describe these"}
+
+
+class TestAnthropicBedrockProvider:
+    """Tests for AnthropicBedrockProvider.get_client_params."""
+
+    @pytest.fixture
+    def bedrock_config(self):
+        return {
+            "API_KEY": "fake",
+            "BASE_URL": None,
+            "MODEL": "claude-3",
+            "TIMEOUT": 60,
+            "EXTRA_HEADERS": None,
+            "EXTRA_BODY": None,
+            "ENABLE_FUNCTIONS": False,
+            "ENABLE_MCP": False,
+            "AWS_ACCESS_KEY_ID": "akid",
+            "AWS_SECRET_ACCESS_KEY": "secret",
+            "AWS_SESSION_TOKEN": "token",
+            "AWS_REGION": "us-east-1",
+        }
+
+    def test_get_client_params_from_config(self, bedrock_config):
+        """AWS credentials from config are mapped into client params."""
+        with patch.object(AnthropicBedrockProvider, "CLIENT_CLS", MagicMock()):
+            provider = AnthropicBedrockProvider(config=bedrock_config)
+            params = provider.get_client_params()
+
+        assert params["aws_access_key"] == "akid"
+        assert params["aws_secret_key"] == "secret"
+        assert params["aws_session_token"] == "token"
+        assert params["aws_region"] == "us-east-1"
+
+    def test_missing_aws_credential_raises(self, bedrock_config, monkeypatch):
+        """Missing AWS credential (absent from config and env) raises ConfigMissingError."""
+        bedrock_config.pop("AWS_REGION")
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        with patch.object(AnthropicBedrockProvider, "CLIENT_CLS", MagicMock()):
+            with pytest.raises(ConfigMissingError, match="AWS_REGION"):
+                AnthropicBedrockProvider(config=bedrock_config)
+
+    def test_missing_aws_credential_from_env(self, bedrock_config, monkeypatch):
+        """A missing config credential is filled from the environment."""
+        bedrock_config.pop("AWS_SESSION_TOKEN")
+        monkeypatch.setenv("AWS_SESSION_TOKEN", "env-token")
+        with patch.object(AnthropicBedrockProvider, "CLIENT_CLS", MagicMock()):
+            provider = AnthropicBedrockProvider(config=bedrock_config)
+
+        assert provider.config["AWS_SESSION_TOKEN"] == "env-token"
+
+
+class TestAnthropicVertexProvider:
+    """Tests for AnthropicVertexProvider.get_client_params."""
+
+    @pytest.fixture
+    def vertex_config(self):
+        return {
+            "API_KEY": "fake",
+            "BASE_URL": None,
+            "MODEL": "claude-3",
+            "TIMEOUT": 60,
+            "EXTRA_HEADERS": None,
+            "EXTRA_BODY": None,
+            "ENABLE_FUNCTIONS": False,
+            "ENABLE_MCP": False,
+            "PROJECT_ID": "my-project",
+            "CLOUD_ML_REGION": "us-central1",
+        }
+
+    def test_get_client_params_from_config(self, vertex_config):
+        """PROJECT_ID and CLOUD_ML_REGION from config are mapped into client params."""
+        with patch.object(AnthropicVertexProvider, "CLIENT_CLS", MagicMock()):
+            provider = AnthropicVertexProvider(config=vertex_config)
+            params = provider.get_client_params()
+
+        assert params["project_id"] == "my-project"
+        assert params["region"] == "us-central1"
+
+    def test_missing_project_id_raises(self, vertex_config, monkeypatch):
+        """Missing PROJECT_ID (absent from config and env) raises ConfigMissingError."""
+        vertex_config.pop("PROJECT_ID")
+        monkeypatch.delenv("PROJECT_ID", raising=False)
+        with patch.object(AnthropicVertexProvider, "CLIENT_CLS", MagicMock()):
+            with pytest.raises(ConfigMissingError, match="PROJECT_ID"):
+                AnthropicVertexProvider(config=vertex_config)
+
+    def test_missing_region_from_env(self, vertex_config, monkeypatch):
+        """A missing CLOUD_ML_REGION is filled from the environment."""
+        vertex_config.pop("CLOUD_ML_REGION")
+        monkeypatch.setenv("CLOUD_ML_REGION", "europe-west1")
+        with patch.object(AnthropicVertexProvider, "CLIENT_CLS", MagicMock()):
+            provider = AnthropicVertexProvider(config=vertex_config)
+
+        assert provider.config["CLOUD_ML_REGION"] == "europe-west1"

--- a/tests/llms/test_client.py
+++ b/tests/llms/test_client.py
@@ -53,6 +53,9 @@ class TestLLMClient:
             "ENABLE_FUNCTIONS": True,
             "ENABLE_MCP": False,
             "MAX_TOOL_CALL_DEPTH": 5,
+            # These tests exercise the silent tool-execution path; confirmation has
+            # its own coverage in tests/llms/test_tool_confirmation.py.
+            "TOOL_CONFIRM": False,
         }
 
     @patch("yaicli.llms.provider.ProviderFactory.create_provider")

--- a/tests/llms/test_cohere_provider.py
+++ b/tests/llms/test_cohere_provider.py
@@ -298,20 +298,18 @@ class TestCohereBadrockProvider:
             "AWS_SESSION_TOKEN": "fake-session-token",
         }
 
-    @patch("yaicli.llms.providers.cohere_provider.BedrockClientV2")
-    def test_init_and_client_creation(self, mock_bedrock_client, mock_config):
-        """Test initialization of CohereBadrockProvider"""
-        mock_client = MagicMock()
-        mock_bedrock_client.return_value = mock_client
+    def test_init_and_client_creation(self, mock_config):
+        """CohereBadrockProvider builds a real BedrockClientV2 from AWS credentials."""
+        from cohere import BedrockClientV2
 
-        # Create a special patched version of create_client that skips the actual API call
-        with patch.object(CohereBadrockProvider, "create_client", return_value=mock_client):
-            provider = CohereBadrockProvider(config=mock_config)
+        provider = CohereBadrockProvider(config=mock_config)
 
-            # Just verify the provider was initialized without errors
-            assert provider is not None
-            # Verify the endpoint URL was set correctly in the config
-            assert provider.config["AWS_REGION"] == "us-east-1"
+        # A real Bedrock client was constructed (not mocked)
+        assert isinstance(provider.client, BedrockClientV2)
+        # AWS credentials were mapped into client_params; the Cohere api_key was dropped
+        assert provider.client_params["aws_region"] == mock_config["AWS_REGION"]
+        assert provider.client_params["aws_access_key"] == mock_config["AWS_ACCESS_KEY_ID"]
+        assert "api_key" not in provider.client_params
 
 
 class TestCohereSagemakerProvider:
@@ -337,17 +335,242 @@ class TestCohereSagemakerProvider:
             "AWS_SESSION_TOKEN": "fake-session-token",
         }
 
-    @patch("yaicli.llms.providers.cohere_provider.SagemakerClientV2")
-    def test_init_and_client_creation(self, mock_sagemaker_client, mock_config):
-        """Test initialization of CohereSagemaker provider"""
-        mock_client = MagicMock()
-        mock_sagemaker_client.return_value = mock_client
+    def test_init_and_client_creation(self, mock_config):
+        """CohereSagemakerProvider builds a real SagemakerClientV2 from AWS credentials."""
+        from cohere import SagemakerClientV2
 
-        # Create a special patched version of create_client that skips the actual API call
-        with patch.object(CohereSagemakerProvider, "create_client", return_value=mock_client):
-            provider = CohereSagemakerProvider(config=mock_config)
+        provider = CohereSagemakerProvider(config=mock_config)
 
-            # Just verify the provider was initialized without errors
-            assert provider is not None
-            # Verify the endpoint URL was set correctly in the config
-            assert provider.config["ENDPOINT_URL"] == "https://example-sagemaker-endpoint.com"
+        # A real Sagemaker client was constructed (not mocked)
+        assert isinstance(provider.client, SagemakerClientV2)
+        assert provider.client_params["aws_region"] == mock_config["AWS_REGION"]
+        assert "api_key" not in provider.client_params
+
+
+class TestCohereProviderMissingBranches:
+    """Tests for missing coverage branches in CohereProvider"""
+
+    @pytest.fixture
+    def mock_config(self):
+        return {
+            "API_KEY": "test_cohere_key",
+            "MODEL": "command-r-plus",
+            "TEMPERATURE": 0.7,
+            "MAX_TOKENS": 1024,
+            "TIMEOUT": 60,
+            "ENABLE_FUNCTIONS": True,
+            "ENABLE_MCP": False,
+        }
+
+    @pytest.fixture
+    def mock_client(self):
+        return MagicMock()
+
+    def test_create_client_with_environment(self, mock_config):
+        """create_client propagates ENVIRONMENT into client_params and builds a real ClientV2.
+
+        cohere's ClientV2 derives its base URL from the environment enum (it reads
+        ``environment.value``), so we pass a real ``ClientEnvironment`` and let the client
+        be constructed for real rather than mocking it away.
+        """
+        from cohere import ClientEnvironment, ClientV2
+
+        mock_config["ENVIRONMENT"] = ClientEnvironment.PRODUCTION
+
+        provider = CohereProvider(config=mock_config)
+
+        # Source: ENVIRONMENT from config is written into client_params
+        assert provider.client_params["environment"] == ClientEnvironment.PRODUCTION
+        # A real ClientV2 instance was created (not a mock)
+        assert isinstance(provider.client, ClientV2)
+
+    def test_prepare_tools_empty_with_verbose(self, mock_config, mock_client):
+        """Test _prepare_tools with no tools and verbose=True"""
+        mock_console = MagicMock()
+
+        with (
+            patch("yaicli.llms.providers.cohere_provider.get_openai_schemas", return_value=[]),
+            patch.object(CohereProvider, "create_client", return_value=mock_client),
+            patch("yaicli.llms.providers.cohere_provider.get_console", return_value=mock_console),
+        ):
+            provider = CohereProvider(config=mock_config, verbose=True)
+            tools = provider._prepare_tools()
+
+        assert tools == []
+        mock_console.print.assert_any_call("No tools available", style="yellow")
+
+    def test_streaming_with_none_chunk(self, mock_config, mock_client):
+        """Test _handle_streaming_response skips None chunks"""
+        with patch.object(CohereProvider, "create_client", return_value=mock_client):
+            provider = CohereProvider(config=mock_config)
+
+        chunk1 = MagicMock()
+        chunk1.type = "content-delta"
+        chunk1.delta.message.content.text = "hello"
+
+        chunks = [None, chunk1, None]
+        responses = list(provider._handle_streaming_response(chunks))
+
+        # Only one response from the valid chunk
+        assert len(responses) == 1
+        assert responses[0].content == "hello"
+
+    def test_streaming_tool_plan_delta(self, mock_config, mock_client):
+        """Test _handle_streaming_response with tool-plan-delta event"""
+        with patch.object(CohereProvider, "create_client", return_value=mock_client):
+            provider = CohereProvider(config=mock_config)
+
+        chunk = MagicMock()
+        chunk.type = "tool-plan-delta"
+        chunk.delta.message.tool_plan = "Planning to call function X"
+
+        responses = list(provider._handle_streaming_response([chunk]))
+
+        assert len(responses) == 1
+        assert responses[0].content == "Planning to call function X"
+
+    def test_streaming_tool_call_delta_without_tool_call(self, mock_config, mock_client):
+        """Test tool-call-delta without prior tool-call-start is skipped"""
+        with patch.object(CohereProvider, "create_client", return_value=mock_client):
+            provider = CohereProvider(config=mock_config)
+
+        chunk = MagicMock()
+        chunk.type = "tool-call-delta"
+        chunk.delta.message.tool_calls.function.arguments = '{"key": "val"}'
+
+        responses = list(provider._handle_streaming_response([chunk]))
+
+        # Should be skipped
+        assert len(responses) == 0
+
+    def test_normal_response_with_content(self, mock_config, mock_client):
+        """Test _handle_normal_response with content items"""
+        with patch.object(CohereProvider, "create_client", return_value=mock_client):
+            provider = CohereProvider(config=mock_config)
+
+        mock_response = MagicMock()
+        mock_content = MagicMock()
+        mock_content.text = "Response text"
+        mock_response.message.content = [mock_content]
+        mock_response.message.tool_calls = None
+
+        responses = list(provider._handle_normal_response(mock_response))
+
+        assert len(responses) == 1
+        assert responses[0].content == "Response text"
+
+    def test_normal_response_with_tool_calls(self, mock_config, mock_client):
+        """Test _handle_normal_response with tool calls"""
+        with patch.object(CohereProvider, "create_client", return_value=mock_client):
+            provider = CohereProvider(config=mock_config)
+
+        mock_response = MagicMock()
+        mock_response.message.content = []
+        mock_response.message.tool_plan = "Using tool X"
+        mock_tool = MagicMock()
+        mock_tool.id = "call_123"
+        mock_tool.function.name = "test_func"
+        mock_tool.function.arguments = '{"key": "val"}'
+        mock_response.message.tool_calls = [mock_tool]
+
+        responses = list(provider._handle_normal_response(mock_response))
+
+        # Should yield tool plan + tool call
+        assert len(responses) == 2
+        assert responses[0].content == "Using tool X"
+        assert responses[1].tool_call.id == "call_123"
+
+    @patch("yaicli.tools.get_openai_schemas")
+    def test_completion_verbose_prints_messages(self, mock_get_schemas, mock_config, mock_client):
+        """Test completion with verbose=True prints messages"""
+        mock_get_schemas.return_value = []
+        mock_console = MagicMock()
+        mock_response = MagicMock()
+        mock_response.message.content = []
+        mock_response.message.tool_calls = None
+        mock_client.chat.return_value = mock_response
+
+        with (
+            patch.object(CohereProvider, "create_client", return_value=mock_client),
+            patch("yaicli.llms.providers.cohere_provider.get_console", return_value=mock_console),
+        ):
+            provider = CohereProvider(config=mock_config, verbose=True)
+            list(provider.completion([ChatMessage(role="user", content="hi")], stream=False))
+
+        # Verify verbose output
+        printed_texts = [str(call.args[0]) for call in mock_console.print.call_args_list]
+        assert any("Messages:" in text for text in printed_texts)
+
+    @patch("yaicli.tools.get_openai_schemas")
+    def test_completion_stream_mode(self, mock_get_schemas, mock_config, mock_client):
+        """Test completion with stream=True"""
+        mock_get_schemas.return_value = []
+
+        chunk = MagicMock()
+        chunk.type = "content-delta"
+        chunk.delta.message.content.text = "stream"
+        mock_client.chat_stream.return_value = [chunk]
+
+        with patch.object(CohereProvider, "create_client", return_value=mock_client):
+            provider = CohereProvider(config=mock_config)
+            responses = list(provider.completion([ChatMessage(role="user", content="hi")], stream=True))
+
+        assert mock_client.chat_stream.called
+        assert len(responses) == 1
+        assert responses[0].content == "stream"
+
+    @patch("yaicli.tools.get_openai_schemas")
+    def test_completion_exception_handling(self, mock_get_schemas, mock_config, mock_client):
+        """Test completion exception is caught and yields error response"""
+        mock_get_schemas.return_value = []
+        mock_client.chat.side_effect = RuntimeError("API error")
+
+        with patch.object(CohereProvider, "create_client", return_value=mock_client):
+            provider = CohereProvider(config=mock_config)
+            responses = list(provider.completion([ChatMessage(role="user", content="hi")], stream=False))
+
+        assert len(responses) == 1
+        assert "Error in Cohere API call" in responses[0].content
+
+    @patch("yaicli.tools.get_openai_schemas")
+    def test_completion_exception_handling_verbose(self, mock_get_schemas, mock_config, mock_client):
+        """Test completion exception with verbose=True prints traceback"""
+        mock_get_schemas.return_value = []
+        mock_client.chat.side_effect = RuntimeError("API error")
+        mock_console = MagicMock()
+
+        with (
+            patch.object(CohereProvider, "create_client", return_value=mock_client),
+            patch("yaicli.llms.providers.cohere_provider.get_console", return_value=mock_console),
+        ):
+            provider = CohereProvider(config=mock_config, verbose=True)
+            responses = list(provider.completion([ChatMessage(role="user", content="hi")], stream=False))
+
+        assert "Error in Cohere API call" in responses[0].content
+        # Verify verbose error output
+        printed = [str(call.args[0]) for call in mock_console.print.call_args_list]
+        assert any("Error in Cohere completion" in text for text in printed)
+
+    @pytest.fixture
+    def bedrock_config(self):
+        return {
+            "API_KEY": "bedrock_key",
+            "MODEL": "cohere.command-r-plus-v1:0",
+            "TEMPERATURE": 0.7,
+            "MAX_TOKENS": 1024,
+            "TIMEOUT": 60,
+            "AWS_REGION": "us-east-1",
+            "AWS_ACCESS_KEY": "access_key",
+            "AWS_SECRET_KEY": "secret_key",
+            "ENABLE_FUNCTIONS": False,
+            "ENABLE_MCP": False,
+        }
+
+    @patch("yaicli.tools.get_openai_schemas", return_value=[])
+    @patch("yaicli.llms.providers.cohere_provider.BedrockClientV2")
+    def test_bedrock_create_client_missing_key(self, mock_bedrock_cls, mock_get_schemas, bedrock_config):
+        """Test CohereBadrockProvider.create_client raises on missing key"""
+        bedrock_config.pop("AWS_REGION")
+
+        with pytest.raises(ValueError, match="AWS_REGION"):
+            CohereBadrockProvider(config=bedrock_config)

--- a/tests/llms/test_longcat_provider.py
+++ b/tests/llms/test_longcat_provider.py
@@ -2,9 +2,22 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from yaicli.llms.providers.anthropic_provider import AnthropicProvider
 from yaicli.llms.providers.longcat_provider import (
     LongCatAnthropicProvider,
     LongCatProvider,
+    _clean_longcat_reasoning,
+    _parse_and_clean_longcat_content,
+)
+from yaicli.llms.providers.openai_provider import OpenAIProvider
+from yaicli.schemas import LLMResponse, ToolCall
+
+LONGCAT_TOOL_CONTENT = (
+    "Let me help.\n"
+    "<longcat_tool_call>test_function\n"
+    "<longcat_arg_key>param1</longcat_arg_key>\n"
+    "<longcat_arg_value>value1</longcat_arg_value>\n"
+    "</longcat_tool_call>"
 )
 
 
@@ -155,3 +168,243 @@ class TestLongCatAnthropicProvider:
             assert responses[0].tool_call is not None
             assert responses[0].tool_call.name == "test_function"
             assert "input_data" in responses[0].tool_call.arguments
+
+
+class TestLongCatHelpers:
+    """Tests for LongCat parsing helper functions."""
+
+    def test_clean_reasoning_empty(self):
+        """Empty reasoning is returned unchanged."""
+        assert _clean_longcat_reasoning("") == ""
+
+    def test_parse_empty_content(self):
+        """Empty content yields no tool call."""
+        assert _parse_and_clean_longcat_content("") == (None, "")
+
+    def test_parse_no_tool_call(self):
+        """Content without a tool call tag yields no tool call."""
+        tool_call, cleaned = _parse_and_clean_longcat_content("just plain text")
+        assert tool_call is None
+        assert cleaned == "just plain text"
+
+    def test_parse_tool_call_tag_without_args(self):
+        """A tool call tag with no arg key/value pairs yields no tool call."""
+        tool_call, _ = _parse_and_clean_longcat_content("<longcat_tool_call>fn</longcat_tool_call>")
+        assert tool_call is None
+
+    def test_parse_verbose_prints(self):
+        """verbose=True prints the extracted tool call name; response_id is used as id."""
+        console = MagicMock()
+        tool_call, _ = _parse_and_clean_longcat_content(
+            LONGCAT_TOOL_CONTENT, response_id="resp_1", verbose=True, console=console
+        )
+        assert tool_call is not None
+        assert tool_call.id == "resp_1"
+        printed = [str(c.args[0]) for c in console.print.call_args_list]
+        assert any("Extracted tool call" in t for t in printed)
+
+    def test_parse_generates_id_when_missing(self):
+        """Without a response_id, a longcat_-prefixed id is generated."""
+        tool_call, _ = _parse_and_clean_longcat_content(LONGCAT_TOOL_CONTENT)
+        assert tool_call is not None
+        assert tool_call.id.startswith("longcat_")
+
+
+class TestLongCatProviderHandlers:
+    """Tests for LongCatProvider response handling (OpenAI-compatible)."""
+
+    @pytest.fixture
+    def mock_config(self):
+        return {
+            "API_KEY": "fake_api_key",
+            "BASE_URL": "https://api.longcat.chat/openai",
+            "MODEL": "longcat-model",
+            "TEMPERATURE": 0.7,
+            "TOP_P": 1.0,
+            "MAX_TOKENS": 1000,
+            "TIMEOUT": 60,
+            "EXTRA_HEADERS": None,
+            "EXTRA_BODY": None,
+            "ENABLE_FUNCTIONS": True,
+            "ENABLE_MCP": False,
+        }
+
+    @pytest.fixture
+    def provider(self, mock_config):
+        with patch("openai.OpenAI"):
+            return LongCatProvider(config=mock_config)
+
+    def test_normal_tool_call_in_reasoning(self, provider):
+        """finish_reason=stop with a tool call hidden in reasoning becomes tool_calls."""
+        std = LLMResponse(reasoning=LONGCAT_TOOL_CONTENT, content="", finish_reason="stop")
+        mock_response = MagicMock()
+        mock_response.id = "resp_1"
+        with patch.object(OpenAIProvider, "_handle_normal_response", return_value=iter([std])):
+            responses = list(provider._handle_normal_response(mock_response))
+
+        assert len(responses) == 1
+        assert responses[0].finish_reason == "tool_calls"
+        assert responses[0].tool_call.name == "test_function"
+
+    def test_normal_reasoning_without_tool_call(self, provider):
+        """finish_reason=stop with reasoning but no tool call yields the std response."""
+        std = LLMResponse(reasoning="just thinking", content="answer", finish_reason="stop")
+        with patch.object(OpenAIProvider, "_handle_normal_response", return_value=iter([std])):
+            responses = list(provider._handle_normal_response(MagicMock()))
+
+        assert responses[0].finish_reason == "stop"
+        assert responses[0].tool_call is None
+
+    def test_normal_non_stop_finish(self, provider):
+        """A non-stop finish reason yields the std response unchanged."""
+        std = LLMResponse(content="hello", finish_reason="length")
+        with patch.object(OpenAIProvider, "_handle_normal_response", return_value=iter([std])):
+            responses = list(provider._handle_normal_response(MagicMock()))
+
+        assert responses[0].content == "hello"
+        assert responses[0].finish_reason == "length"
+
+    def test_stream_tool_call_in_reasoning(self, provider):
+        """Streaming: reasoning accumulates a tool call, finish=stop -> tool_calls."""
+        chunks = [
+            LLMResponse(reasoning=LONGCAT_TOOL_CONTENT, content=""),
+            LLMResponse(content="", finish_reason="stop"),
+        ]
+        mock_response = MagicMock()
+        mock_response.id = "resp_1"
+        with patch.object(OpenAIProvider, "_handle_stream_response", return_value=iter(chunks)):
+            responses = list(provider._handle_stream_response(mock_response))
+
+        tool_responses = [r for r in responses if r.tool_call]
+        assert tool_responses
+        assert tool_responses[0].finish_reason == "tool_calls"
+        assert tool_responses[0].tool_call.name == "test_function"
+
+    def test_stream_passthrough_tool_calls(self, provider):
+        """Streaming: a chunk already marked tool_calls passes through."""
+        tc = ToolCall(id="t1", name="fn", arguments="{}")
+        chunks = [LLMResponse(content="", finish_reason="tool_calls", tool_call=tc)]
+        with patch.object(OpenAIProvider, "_handle_stream_response", return_value=iter(chunks)):
+            responses = list(provider._handle_stream_response(MagicMock()))
+
+        assert responses[0].finish_reason == "tool_calls"
+        assert responses[0].tool_call.id == "t1"
+
+    def test_stream_plain_content(self, provider):
+        """Streaming: plain content chunks (no tool call) yield as-is."""
+        chunks = [LLMResponse(content="hello "), LLMResponse(content="world", finish_reason="stop")]
+        with patch.object(OpenAIProvider, "_handle_stream_response", return_value=iter(chunks)):
+            responses = list(provider._handle_stream_response(MagicMock()))
+
+        contents = "".join(r.content for r in responses if r.content)
+        assert "hello world" in contents
+
+
+class TestLongCatAnthropicHandlers:
+    """Tests for LongCatAnthropicProvider response handling (Anthropic-compatible)."""
+
+    @pytest.fixture
+    def mock_config(self):
+        return {
+            "API_KEY": "fake_api_key",
+            "BASE_URL": "https://api.longcat.chat/anthropic",
+            "MODEL": "longcat-claude-model",
+            "TEMPERATURE": 0.7,
+            "TOP_P": 1.0,
+            "MAX_TOKENS": 1000,
+            "TIMEOUT": 60,
+            "EXTRA_HEADERS": None,
+            "EXTRA_BODY": None,
+            "ENABLE_FUNCTIONS": True,
+            "ENABLE_MCP": False,
+        }
+
+    @pytest.fixture
+    def provider(self, mock_config):
+        with patch("yaicli.llms.providers.anthropic_provider.Anthropic"):
+            return LongCatAnthropicProvider(config=mock_config)
+
+    def test_get_client_params_with_extra_headers(self, mock_config):
+        """EXTRA_HEADERS are merged into default_headers alongside the Bearer token."""
+        mock_config["EXTRA_HEADERS"] = {"X-Custom": "v"}
+        with patch("yaicli.llms.providers.anthropic_provider.Anthropic"):
+            provider = LongCatAnthropicProvider(config=mock_config)
+            params = provider.get_client_params()
+
+        assert params["default_headers"]["X-Custom"] == "v"
+        assert params["default_headers"]["Authorization"] == "Bearer fake_api_key"
+        assert params["timeout"] == 60
+
+    def test_normal_passthrough_tool_use(self, provider):
+        """A parent-detected tool_use response is yielded as-is."""
+        tc = ToolCall(id="t1", name="fn", arguments="{}")
+        std = LLMResponse(content="x", finish_reason="tool_use", tool_call=tc)
+        with patch.object(AnthropicProvider, "_handle_normal_response", return_value=iter([std])):
+            responses = list(provider._handle_normal_response(MagicMock()))
+
+        assert responses[0].finish_reason == "tool_use"
+        assert responses[0].tool_call.id == "t1"
+
+    def test_normal_tool_call_in_reasoning(self, provider):
+        """end_turn with a tool call embedded in reasoning becomes tool_use."""
+        std = LLMResponse(reasoning=LONGCAT_TOOL_CONTENT, content="", finish_reason="end_turn")
+        mock_response = MagicMock()
+        mock_response.id = "resp_1"
+        with patch.object(AnthropicProvider, "_handle_normal_response", return_value=iter([std])):
+            responses = list(provider._handle_normal_response(mock_response))
+
+        assert responses[0].finish_reason == "tool_use"
+        assert responses[0].tool_call.name == "test_function"
+
+    def test_normal_end_turn_no_tool_call(self, provider):
+        """end_turn without any tool call yields the original response."""
+        std = LLMResponse(content="plain answer", finish_reason="end_turn")
+        with patch.object(AnthropicProvider, "_handle_normal_response", return_value=iter([std])):
+            responses = list(provider._handle_normal_response(MagicMock()))
+
+        assert responses[0].content == "plain answer"
+        assert responses[0].finish_reason == "end_turn"
+        assert responses[0].tool_call is None
+
+    def test_normal_other_finish_reason(self, provider):
+        """A finish reason that is neither tool_use nor end_turn passes through."""
+        std = LLMResponse(content="partial", finish_reason="max_tokens")
+        with patch.object(AnthropicProvider, "_handle_normal_response", return_value=iter([std])):
+            responses = list(provider._handle_normal_response(MagicMock()))
+
+        assert responses[0].finish_reason == "max_tokens"
+
+    def test_stream_tool_call_in_content(self, provider):
+        """Streaming: tool call accumulates in content, finish=stop -> tool_use."""
+        chunks = [
+            LLMResponse(content=LONGCAT_TOOL_CONTENT),
+            LLMResponse(content="", finish_reason="stop"),
+        ]
+        mock_response = MagicMock()
+        mock_response.id = "resp_1"
+        with patch.object(AnthropicProvider, "_handle_stream_response", return_value=iter(chunks)):
+            responses = list(provider._handle_stream_response(mock_response))
+
+        tool_responses = [r for r in responses if r.tool_call]
+        assert tool_responses
+        assert tool_responses[0].finish_reason == "tool_use"
+        assert tool_responses[0].tool_call.name == "test_function"
+
+    def test_stream_passthrough_tool_use(self, provider):
+        """Streaming: a chunk already marked tool_use passes through."""
+        tc = ToolCall(id="t1", name="fn", arguments="{}")
+        chunks = [LLMResponse(content="", finish_reason="tool_use", tool_call=tc)]
+        with patch.object(AnthropicProvider, "_handle_stream_response", return_value=iter(chunks)):
+            responses = list(provider._handle_stream_response(MagicMock()))
+
+        assert responses[0].finish_reason == "tool_use"
+        assert responses[0].tool_call.id == "t1"
+
+    def test_stream_plain_content(self, provider):
+        """Streaming: plain content yields as-is."""
+        chunks = [LLMResponse(content="hello "), LLMResponse(content="world", finish_reason="end_turn")]
+        with patch.object(AnthropicProvider, "_handle_stream_response", return_value=iter(chunks)):
+            responses = list(provider._handle_stream_response(MagicMock()))
+
+        contents = "".join(r.content for r in responses if r.content)
+        assert "hello world" in contents

--- a/tests/llms/test_minimax_provider.py
+++ b/tests/llms/test_minimax_provider.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from yaicli.llms.providers.minimax_provider import MinimaxProvider
-from yaicli.schemas import ChatMessage, ToolCall, ToolPolicy
+from yaicli.schemas import ChatMessage, LLMResponse, ToolCall, ToolPolicy
 
 
 class TestMinimaxProvider:
@@ -201,3 +201,182 @@ class TestMinimaxProvider:
         }
 
         assert provider.COMPLETION_PARAMS_KEYS == expected_keys
+
+    def test_convert_messages_with_name_field(self, provider):
+        """Test message conversion with name field"""
+        messages = [ChatMessage(role="user", content="Hello", name="test_user")]
+
+        converted = provider._convert_messages(messages)
+
+        assert converted[0]["name"] == "test_user"
+
+    def test_convert_messages_with_tool_role(self, provider):
+        """Test message conversion with tool role and tool_call_id"""
+        messages = [ChatMessage(role="tool", content="result", tool_call_id="call_123")]
+
+        converted = provider._convert_messages(messages)
+
+        assert converted[0]["role"] == "tool"
+        assert converted[0]["tool_call_id"] == "call_123"
+
+    def test_get_reasoning_content_with_non_dict_delta(self, provider):
+        """Test _get_reasoning_content converts non-dict delta"""
+        # Create a mock object that behaves like a dict when converted
+        class MockDelta:
+            def __init__(self, data):
+                self._data = data
+
+            def __iter__(self):
+                return iter(self._data.items())
+
+        mock_delta = MockDelta({"reasoning_details": [{"text": "thinking"}]})
+        reasoning = provider._get_reasoning_content(mock_delta)
+
+        # Should handle the conversion gracefully
+        assert reasoning == "thinking"
+
+    def test_handle_stream_response(self, provider):
+        """Test streaming response handling"""
+        # Create mock chunks
+        chunk1 = MagicMock()
+        choice1 = MagicMock()
+        delta1 = MagicMock()
+        delta1.content = "Hello"
+        delta1.model_extra = None
+        delta1.tool_calls = None
+        choice1.delta = delta1
+        choice1.finish_reason = None
+        chunk1.choices = [choice1]
+
+        chunk2 = MagicMock()
+        choice2 = MagicMock()
+        delta2 = MagicMock()
+        delta2.content = " world"
+        delta2.model_extra = None
+        delta2.tool_calls = None
+        choice2.delta = delta2
+        choice2.finish_reason = "stop"
+        chunk2.choices = [choice2]
+
+        responses = list(provider._handle_stream_response([chunk1, chunk2]))
+
+        assert len(responses) == 2
+        assert responses[0].content == "Hello"
+        assert responses[1].content == " world"
+        assert responses[1].finish_reason == "stop"
+
+    def test_handle_stream_response_with_reasoning(self, provider):
+        """Test streaming response with reasoning_details"""
+        chunk = MagicMock()
+        choice = MagicMock()
+        delta = MagicMock()
+        delta.content = "answer"
+        delta.model_extra = {"reasoning_details": [{"text": "thinking"}]}
+        delta.tool_calls = None
+        choice.delta = delta
+        choice.finish_reason = "stop"
+        chunk.choices = [choice]
+
+        responses = list(provider._handle_stream_response([chunk]))
+
+        assert responses[0].reasoning == "thinking"
+        assert responses[0].content == "answer"
+
+    def test_handle_stream_response_empty_first_chunk(self, provider):
+        """Test streaming with empty first chunk"""
+        chunk1 = MagicMock()
+        chunk1.choices = []
+
+        chunk2 = MagicMock()
+        choice2 = MagicMock()
+        delta2 = MagicMock()
+        delta2.content = "ok"
+        delta2.model_extra = None
+        delta2.tool_calls = None
+        choice2.delta = delta2
+        choice2.finish_reason = "stop"
+        chunk2.choices = [choice2]
+
+        responses = list(provider._handle_stream_response([chunk1, chunk2]))
+
+        # First empty chunk is skipped
+        assert len(responses) == 1
+        assert responses[0].content == "ok"
+
+    def test_handle_stream_response_first_chunk_error(self, provider):
+        """Test streaming with first chunk error response"""
+        chunk1 = MagicMock()
+        chunk1.choices = []
+
+        chunk2 = MagicMock()
+        choice2 = MagicMock()
+        delta2 = MagicMock()
+        delta2.content = "ok"
+        delta2.model_extra = None
+        delta2.tool_calls = None
+        choice2.delta = delta2
+        choice2.finish_reason = "stop"
+        chunk2.choices = [choice2]
+
+        with patch.object(provider, "_first_chunk_error", return_value=LLMResponse(content="error", finish_reason="stop")):
+            responses = list(provider._handle_stream_response([chunk1, chunk2]))
+
+        # Should yield the error response first
+        assert responses[0].content == "error"
+        assert responses[1].content == "ok"
+
+    def test_handle_stream_response_mid_empty_chunk(self, provider):
+        """Test streaming with empty chunk in the middle"""
+        chunk1 = MagicMock()
+        choice1 = MagicMock()
+        delta1 = MagicMock()
+        delta1.content = "a"
+        delta1.model_extra = None
+        delta1.tool_calls = None
+        choice1.delta = delta1
+        choice1.finish_reason = None
+        chunk1.choices = [choice1]
+
+        chunk2 = MagicMock()
+        chunk2.choices = []  # Empty chunk
+
+        chunk3 = MagicMock()
+        choice3 = MagicMock()
+        delta3 = MagicMock()
+        delta3.content = "b"
+        delta3.model_extra = None
+        delta3.tool_calls = None
+        choice3.delta = delta3
+        choice3.finish_reason = "stop"
+        chunk3.choices = [choice3]
+
+        responses = list(provider._handle_stream_response([chunk1, chunk2, chunk3]))
+
+        # Middle empty chunk should be skipped
+        assert len(responses) == 2
+        assert responses[0].content == "a"
+        assert responses[1].content == "b"
+
+    def test_handle_stream_response_with_tool_call(self, provider):
+        """Test streaming response with tool call"""
+        chunk = MagicMock()
+        choice = MagicMock()
+        delta = MagicMock()
+        delta.content = ""
+        delta.model_extra = None
+
+        mock_tool = MagicMock()
+        mock_tool.id = "call_123"
+        mock_tool.function.name = "test_func"
+        mock_tool.function.arguments = '{"key": "val"}'
+        delta.tool_calls = [mock_tool]
+
+        choice.delta = delta
+        choice.finish_reason = "tool_calls"
+        chunk.choices = [choice]
+
+        responses = list(provider._handle_stream_response([chunk]))
+
+        assert responses[0].tool_call is not None
+        assert responses[0].tool_call.id == "call_123"
+        assert responses[0].finish_reason == "tool_calls"

--- a/tests/llms/test_openai_compatible_provider.py
+++ b/tests/llms/test_openai_compatible_provider.py
@@ -1,0 +1,171 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from yaicli.llms.providers.openai_compatible_provider import OpenAICompatibleProvider
+from yaicli.schemas import ChatMessage, LLMResponse
+
+
+def make_tool_call(tc_id=None, name=None, arguments=""):
+    """Build a mock streaming tool-call delta entry"""
+    tc = MagicMock()
+    tc.id = tc_id
+    tc.function.name = name
+    tc.function.arguments = arguments
+    return tc
+
+
+def make_chunk(content="", finish_reason=None, tool_calls=None, model_extra=None, choices_empty=False):
+    """Build a mock streaming chunk"""
+    chunk = MagicMock()
+    if choices_empty:
+        chunk.choices = []
+        return chunk
+    choice = MagicMock()
+    delta = MagicMock()
+    delta.content = content
+    delta.model_extra = model_extra
+    delta.tool_calls = tool_calls
+    choice.delta = delta
+    choice.finish_reason = finish_reason
+    chunk.choices = [choice]
+    return chunk
+
+
+class TestOpenAICompatibleProvider:
+    """Tests for OpenAICompatibleProvider streaming logic (complete-JSON detection)"""
+
+    @pytest.fixture
+    def mock_config(self):
+        return {
+            "API_KEY": "fake_api_key",
+            "BASE_URL": "https://fake-compatible.example.com/v1",
+            "MODEL": "compatible-model",
+            "TEMPERATURE": 0.7,
+            "TOP_P": 1.0,
+            "MAX_TOKENS": 1000,
+            "TIMEOUT": 60,
+            "EXTRA_HEADERS": None,
+            "EXTRA_BODY": None,
+            "ENABLE_FUNCTIONS": True,
+            "ENABLE_MCP": False,
+        }
+
+    def _make_provider(self, mock_config, chunks):
+        with patch("yaicli.llms.providers.openai_provider.openai.OpenAI"):
+            provider = OpenAICompatibleProvider(config=mock_config)
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = chunks
+        provider.client = mock_client
+        return provider
+
+    @patch("yaicli.tools.get_openai_schemas", return_value=[])
+    def test_streaming_plain_text(self, _schemas, mock_config):
+        """Plain text streaming yields one response per chunk with no tool call"""
+        chunks = [
+            make_chunk(content="Hello", finish_reason=None, tool_calls=None),
+            make_chunk(content=" world", finish_reason=None, tool_calls=None),
+            make_chunk(content="!", finish_reason="stop", tool_calls=None),
+        ]
+        provider = self._make_provider(mock_config, chunks)
+        responses = list(provider.completion([ChatMessage(role="user", content="hi")], stream=True))
+
+        assert [r.content for r in responses] == ["Hello", " world", "!"]
+        assert responses[-1].finish_reason == "stop"
+        assert all(r.tool_call is None for r in responses)
+
+    @patch("yaicli.tools.get_openai_schemas", return_value=[])
+    def test_streaming_reasoning_content(self, _schemas, mock_config):
+        """Reasoning content in model_extra is surfaced on the response"""
+        chunks = [
+            make_chunk(
+                content="answer",
+                finish_reason="stop",
+                tool_calls=None,
+                model_extra={"reasoning_content": "thinking hard"},
+            ),
+        ]
+        provider = self._make_provider(mock_config, chunks)
+        responses = list(provider.completion([ChatMessage(role="user", content="hi")], stream=True))
+
+        assert responses[0].reasoning == "thinking hard"
+        assert responses[0].content == "answer"
+
+    @patch("yaicli.tools.get_openai_schemas", return_value=[])
+    def test_tool_call_returned_early_on_complete_json(self, _schemas, mock_config):
+        """A single chunk carrying complete JSON args returns the tool call even without finish_reason"""
+        chunks = [
+            make_chunk(
+                content="",
+                finish_reason=None,
+                tool_calls=[make_tool_call("call_1", "get_weather", '{"location": "NYC"}')],
+            ),
+        ]
+        provider = self._make_provider(mock_config, chunks)
+        responses = list(provider.completion([ChatMessage(role="user", content="weather?")], stream=True))
+
+        assert responses[0].tool_call is not None
+        assert responses[0].tool_call.id == "call_1"
+        assert responses[0].tool_call.name == "get_weather"
+        assert responses[0].tool_call.arguments == '{"location": "NYC"}'
+        # finish_reason is synthesized as tool_calls even though the chunk had none
+        assert responses[0].finish_reason == "tool_calls"
+
+    @patch("yaicli.tools.get_openai_schemas", return_value=[])
+    def test_tool_call_incomplete_json_then_complete(self, _schemas, mock_config):
+        """Partial JSON args do not return a tool call until the JSON parses"""
+        chunks = [
+            make_chunk(content="", finish_reason=None, tool_calls=[make_tool_call("call_1", "f", '{"x": ')]),
+            make_chunk(content="", finish_reason="tool_calls", tool_calls=[make_tool_call(None, None, "1}")]),
+        ]
+        provider = self._make_provider(mock_config, chunks)
+        responses = list(provider.completion([ChatMessage(role="user", content="go")], stream=True))
+
+        # First chunk: JSON not yet valid -> no tool call surfaced
+        assert responses[0].tool_call is None
+        # Second chunk: JSON complete and finish_reason set -> tool call surfaced
+        assert responses[1].tool_call is not None
+        assert responses[1].tool_call.arguments == '{"x": 1}'
+        assert responses[1].finish_reason == "tool_calls"
+
+    @patch("yaicli.tools.get_openai_schemas", return_value=[])
+    def test_first_chunk_without_choices_is_skipped(self, _schemas, mock_config):
+        """An error-shaped first chunk with no choices is skipped, not yielded"""
+        chunks = [
+            make_chunk(choices_empty=True),
+            make_chunk(content="hi", finish_reason="stop", tool_calls=None),
+        ]
+        provider = self._make_provider(mock_config, chunks)
+        responses = list(provider.completion([ChatMessage(role="user", content="hi")], stream=True))
+
+        assert len(responses) == 1
+        assert responses[0].content == "hi"
+
+    @patch("yaicli.tools.get_openai_schemas", return_value=[])
+    def test_first_chunk_error_response_is_yielded(self, _schemas, mock_config):
+        """When _first_chunk_error returns a response, it is yielded before the stream proper"""
+        chunks = [
+            make_chunk(choices_empty=True),
+            make_chunk(content="ok", finish_reason="stop", tool_calls=None),
+        ]
+        provider = self._make_provider(mock_config, chunks)
+        with patch.object(
+            provider, "_first_chunk_error", return_value=LLMResponse(content="err", finish_reason="stop")
+        ):
+            responses = list(provider.completion([ChatMessage(role="user", content="hi")], stream=True))
+
+        assert responses[0].content == "err"
+        assert responses[1].content == "ok"
+
+    @patch("yaicli.tools.get_openai_schemas", return_value=[])
+    def test_mid_stream_chunk_without_choices_is_skipped(self, _schemas, mock_config):
+        """A no-choices chunk in the middle of the stream is skipped"""
+        chunks = [
+            make_chunk(content="a", finish_reason=None, tool_calls=None),
+            make_chunk(choices_empty=True),
+            make_chunk(content="b", finish_reason="stop", tool_calls=None),
+        ]
+        provider = self._make_provider(mock_config, chunks)
+        responses = list(provider.completion([ChatMessage(role="user", content="hi")], stream=True))
+
+        assert [r.content for r in responses] == ["a", "b"]

--- a/tests/llms/test_sambanova_provider.py
+++ b/tests/llms/test_sambanova_provider.py
@@ -1,0 +1,110 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from yaicli.const import DEFAULT_TEMPERATURE
+from yaicli.llms.providers.sambanova_provider import SambanovaProvider
+from yaicli.schemas import ToolPolicy
+
+
+class TestSambanovaProvider:
+    """Tests for Sambanova provider implementation"""
+
+    @pytest.fixture
+    def mock_config(self):
+        """Fixture to create a mock configuration with a function-call-capable model"""
+        return {
+            "API_KEY": "fake_api_key",
+            "BASE_URL": None,  # Will use DEFAULT_BASE_URL
+            "MODEL": "Meta-Llama-3.3-70B-Instruct",
+            "TEMPERATURE": 0.7,
+            "TOP_P": 0.9,
+            "MAX_TOKENS": 1024,
+            "TIMEOUT": 10,
+            "FREQUENCY_PENALTY": 0.0,
+            "EXTRA_HEADERS": None,
+            "EXTRA_BODY": None,
+            "ENABLE_FUNCTIONS": True,
+            "ENABLE_MCP": False,
+        }
+
+    def test_init(self, mock_config):
+        """Test initialization of SambanovaProvider"""
+        with patch("yaicli.llms.providers.openai_provider.openai.OpenAI"):
+            provider = SambanovaProvider(config=mock_config)
+
+            assert provider.client_params["base_url"] == SambanovaProvider.DEFAULT_BASE_URL
+            assert provider.client_params["base_url"] == "https://api.sambanova.ai/v1"
+            assert provider.client_params["api_key"] == mock_config["API_KEY"]
+
+    def test_temperature_in_range_unchanged(self, mock_config):
+        """Temperature within [0, 1] should be left untouched and emit no warning"""
+        mock_console = MagicMock()
+        with (
+            patch("yaicli.llms.providers.openai_provider.openai.OpenAI"),
+            patch("yaicli.llms.providers.openai_provider.get_console", return_value=mock_console),
+        ):
+            provider = SambanovaProvider(config=mock_config)
+            params = provider.get_completion_params(tool_policy=ToolPolicy(True, False))
+
+            assert params["temperature"] == 0.7
+            # Supported model + in-range temperature => no warnings printed
+            mock_console.print.assert_not_called()
+
+    @pytest.mark.parametrize("bad_temp", [1.5, -0.5, 2.0])
+    def test_temperature_out_of_range_reset(self, mock_config, bad_temp):
+        """Temperature outside [0, 1] should be reset to DEFAULT_TEMPERATURE with a warning"""
+        mock_config["TEMPERATURE"] = bad_temp
+        mock_console = MagicMock()
+        with (
+            patch("yaicli.llms.providers.openai_provider.openai.OpenAI"),
+            patch("yaicli.llms.providers.openai_provider.get_console", return_value=mock_console),
+        ):
+            provider = SambanovaProvider(config=mock_config)
+            params = provider.get_completion_params(tool_policy=ToolPolicy(True, False))
+
+            assert params["temperature"] == DEFAULT_TEMPERATURE
+            mock_console.print.assert_any_call(
+                "Sambanova temperature must be between 0 and 1, setting to 0.4", style="yellow"
+            )
+
+    def test_unsupported_model_with_functions_warns(self, mock_config):
+        """An unsupported model with functions enabled should warn about function-call support"""
+        mock_config["MODEL"] = "some-unsupported-model"
+        mock_console = MagicMock()
+        with (
+            patch("yaicli.llms.providers.openai_provider.openai.OpenAI"),
+            patch("yaicli.llms.providers.openai_provider.get_console", return_value=mock_console),
+        ):
+            provider = SambanovaProvider(config=mock_config)
+            provider.get_completion_params(tool_policy=ToolPolicy(True, False))
+
+            printed = " ".join(str(call.args[0]) for call in mock_console.print.call_args_list)
+            assert "Sambanova supports function call models" in printed
+
+    def test_unsupported_model_without_functions_no_warn(self, mock_config):
+        """An unsupported model with functions disabled should not warn about function-call support"""
+        mock_config["MODEL"] = "some-unsupported-model"
+        mock_console = MagicMock()
+        with (
+            patch("yaicli.llms.providers.openai_provider.openai.OpenAI"),
+            patch("yaicli.llms.providers.openai_provider.get_console", return_value=mock_console),
+        ):
+            provider = SambanovaProvider(config=mock_config)
+            provider.get_completion_params(tool_policy=ToolPolicy(False, False))
+
+            printed = " ".join(str(call.args[0]) for call in mock_console.print.call_args_list)
+            assert "Sambanova supports function call models" not in printed
+
+    def test_supported_model_with_functions_no_warn(self, mock_config):
+        """A supported model with functions enabled should not emit the function-call warning"""
+        mock_console = MagicMock()
+        with (
+            patch("yaicli.llms.providers.openai_provider.openai.OpenAI"),
+            patch("yaicli.llms.providers.openai_provider.get_console", return_value=mock_console),
+        ):
+            provider = SambanovaProvider(config=mock_config)
+            provider.get_completion_params(tool_policy=ToolPolicy(True, False))
+
+            printed = " ".join(str(call.args[0]) for call in mock_console.print.call_args_list)
+            assert "Sambanova supports function call models" not in printed

--- a/tests/llms/test_simple_providers.py
+++ b/tests/llms/test_simple_providers.py
@@ -165,6 +165,68 @@ class TestGroqProvider:
 
             assert params["model"] == mock_config["MODEL"]
 
+    def test_reasoning_effort_invalid_value_reset_to_default(self, mock_config):
+        """Test invalid reasoning_effort is reset to default with warning"""
+        mock_config["EXTRA_BODY"] = None
+        mock_config["REASONING_EFFORT"] = "high"
+        mock_config["MODEL"] = "qwen3-model"
+        mock_console = MagicMock()
+
+        with (
+            patch("yaicli.llms.providers.openai_provider.openai.OpenAI"),
+            patch("yaicli.llms.providers.openai_provider.get_console", return_value=mock_console),
+        ):
+            provider = GroqProvider(config=mock_config)
+            params = provider.get_completion_params()
+
+            assert params["reasoning_effort"] == "default"
+            mock_console.print.assert_any_call(
+                "Groq only supports null or default for reasoning_effort, setting to default", style="yellow"
+            )
+
+    def test_reasoning_effort_non_qwen3_model_set_to_none(self, mock_config):
+        """Test reasoning_effort on non-qwen3 model is set to None with warning"""
+        mock_config["EXTRA_BODY"] = None
+        mock_config["REASONING_EFFORT"] = "default"
+        mock_config["MODEL"] = "llama3-model"
+        mock_console = MagicMock()
+
+        with (
+            patch("yaicli.llms.providers.openai_provider.openai.OpenAI"),
+            patch("yaicli.llms.providers.openai_provider.get_console", return_value=mock_console),
+        ):
+            provider = GroqProvider(config=mock_config)
+            params = provider.get_completion_params()
+
+            assert params["reasoning_effort"] is None
+            mock_console.print.assert_any_call(
+                "Groq only supports reasoning_effort for qwen3, setting to null", style="yellow"
+            )
+
+    def test_reasoning_effort_null_string_converted_to_none(self, mock_config):
+        """Test reasoning_effort='null' is converted to None"""
+        mock_config["EXTRA_BODY"] = None
+        mock_config["REASONING_EFFORT"] = "null"
+
+        with patch("yaicli.llms.providers.openai_provider.openai.OpenAI"):
+            provider = GroqProvider(config=mock_config)
+            params = provider.get_completion_params()
+
+            assert params["reasoning_effort"] is None
+
+    def test_reasoning_effort_null_on_qwen3_converted_to_none(self, mock_config):
+        """Test reasoning_effort='null' on qwen3 model is converted to None"""
+        mock_config["EXTRA_BODY"] = None
+        mock_config["REASONING_EFFORT"] = "null"
+        mock_config["MODEL"] = "qwen3-70b"
+
+        with patch("yaicli.llms.providers.openai_provider.openai.OpenAI"):
+            provider = GroqProvider(config=mock_config)
+            params = provider.get_completion_params()
+
+            # Should hit the final 'null' -> None conversion
+            assert params["reasoning_effort"] is None
+
 
 class TestInfiniAIProvider:
     """Tests for InfiniAI provider implementation"""

--- a/tests/llms/test_targon_provider.py
+++ b/tests/llms/test_targon_provider.py
@@ -1,0 +1,55 @@
+from unittest.mock import patch
+
+import pytest
+
+from yaicli.llms.providers.targon_provider import TargonProvider
+from yaicli.schemas import ToolPolicy
+
+
+class TestTargonProvider:
+    """Tests for Targon provider implementation"""
+
+    @pytest.fixture
+    def mock_config(self):
+        """Fixture to create a mock configuration"""
+        return {
+            "API_KEY": "fake_api_key",
+            "BASE_URL": None,  # Will use DEFAULT_BASE_URL
+            "MODEL": "targon-model",
+            "TEMPERATURE": 0.7,
+            "TOP_P": 0.9,
+            "MAX_TOKENS": 1024,
+            "TIMEOUT": 10,
+            "FREQUENCY_PENALTY": 0.0,
+            "EXTRA_HEADERS": None,
+            "EXTRA_BODY": None,
+            "ENABLE_FUNCTIONS": True,
+            "ENABLE_MCP": False,
+        }
+
+    def test_init(self, mock_config):
+        """Test initialization of TargonProvider"""
+        with patch("yaicli.llms.providers.openai_provider.openai.OpenAI"):
+            provider = TargonProvider(config=mock_config)
+
+            assert provider.client_params["base_url"] == TargonProvider.DEFAULT_BASE_URL
+            assert provider.client_params["base_url"] == "https://api.targon.com/v1"
+            assert provider.client_params["api_key"] == mock_config["API_KEY"]
+
+    def test_custom_base_url(self, mock_config):
+        """Test Targon provider with a custom base URL"""
+        mock_config["BASE_URL"] = "https://custom.targon.example.com"
+        with patch("yaicli.llms.providers.openai_provider.openai.OpenAI"):
+            provider = TargonProvider(config=mock_config)
+            assert provider.client_params["base_url"] == "https://custom.targon.example.com"
+
+    def test_completion_params_mapping(self, mock_config):
+        """Test that Targon maps frequency_penalty and uses max_tokens, not max_completion_tokens"""
+        with patch("yaicli.llms.providers.openai_provider.openai.OpenAI"):
+            provider = TargonProvider(config=mock_config)
+            params = provider.get_completion_params(tool_policy=ToolPolicy(True, False))
+
+            assert params["model"] == mock_config["MODEL"]
+            assert params["max_tokens"] == mock_config["MAX_TOKENS"]
+            assert "max_completion_tokens" not in params
+            assert params["frequency_penalty"] == mock_config["FREQUENCY_PENALTY"]

--- a/tests/llms/test_tool_confirmation.py
+++ b/tests/llms/test_tool_confirmation.py
@@ -1,0 +1,240 @@
+from unittest.mock import patch
+
+from yaicli.llms.client import LLMClient
+from yaicli.llms.provider import ProviderFactory
+from yaicli.schemas import (
+    ChatMessage,
+    ConfirmToolCall,
+    LLMResponse,
+    ToolCall,
+    ToolConfirmDecision,
+    ToolPolicy,
+)
+from yaicli.tools.approval import ToolApprovalManager
+
+
+class FakeProvider:
+    """Minimal provider that replays scripted LLMResponse batches, one per completion() call."""
+
+    def __init__(self, scripted):
+        self._scripted = scripted
+        self.calls = 0
+
+    def resolve_tool_policy(self, tool_policy):
+        return tool_policy or ToolPolicy(enable_functions=True, enable_mcp=True)
+
+    def completion(self, messages, stream=False, tool_policy=None):
+        batch = self._scripted[self.calls]
+        self.calls += 1
+        yield from batch
+
+    def detect_tool_role(self):
+        return "tool"
+
+
+def make_client(scripted, approval, *, interactive=True, tool_confirm=True):
+    config = {
+        "ENABLE_FUNCTIONS": True,
+        "ENABLE_MCP": True,
+        "MAX_TOOL_CALL_DEPTH": 8,
+        "TOOL_CONFIRM": tool_confirm,
+    }
+    fake = FakeProvider(scripted)
+    with patch.object(ProviderFactory, "create_provider", return_value=fake):
+        client = LLMClient(provider_name="openai", config=config, approval=approval, interactive=interactive)
+    client.provider = fake
+    return client
+
+
+def drive(gen, decisions):
+    """Pump a completion_with_tools generator, answering ConfirmToolCall with queued decisions.
+
+    Returns (collected_items, num_confirms).
+    """
+    decisions = list(decisions)
+    items = []
+    send_value = None
+    confirms = 0
+    while True:
+        try:
+            item = gen.send(send_value) if send_value is not None else next(gen)
+        except StopIteration:
+            break
+        send_value = None
+        items.append(item)
+        if isinstance(item, ConfirmToolCall):
+            confirms += 1
+            send_value = decisions.pop(0)
+    return items, confirms
+
+
+def _tool_then_done(tc):
+    """Script: first turn returns a tool call, recursion returns final content."""
+    return [
+        [LLMResponse(tool_call=tc, finish_reason="tool_calls")],
+        [LLMResponse(content="done", finish_reason="stop")],
+    ]
+
+
+def _tool_messages(messages):
+    return [m for m in messages if m.role == "tool"]
+
+
+def test_approve_once_executes_but_is_not_remembered(tmp_path):
+    approval = ToolApprovalManager(permissions_path=tmp_path / "p.json")
+    tc = ToolCall(id="c1", name="get_weather", arguments="{}")
+    client = make_client(_tool_then_done(tc), approval)
+    messages = [ChatMessage(role="user", content="weather?")]
+
+    with patch("yaicli.llms.client.execute_tool_call", return_value=("ok", True)) as ex:
+        gen = client.completion_with_tools(messages, tool_policy=ToolPolicy(True, True))
+        _, confirms = drive(gen, [ToolConfirmDecision.ONCE])
+
+    assert confirms == 1
+    ex.assert_called_once()
+    # "once" must not be remembered
+    assert approval.is_allowed("get_weather") is False
+    tool_msgs = _tool_messages(messages)
+    assert len(tool_msgs) == 1 and tool_msgs[0].tool_call_id == "c1"
+
+
+def test_session_approval_skips_later_prompts(tmp_path):
+    approval = ToolApprovalManager(permissions_path=tmp_path / "p.json")
+
+    # Turn 1: approve for the session
+    tc1 = ToolCall(id="c1", name="get_weather", arguments="{}")
+    client1 = make_client(_tool_then_done(tc1), approval)
+    with patch("yaicli.llms.client.execute_tool_call", return_value=("ok", True)):
+        gen1 = client1.completion_with_tools([ChatMessage(role="user", content="x")], tool_policy=ToolPolicy(True, True))
+        _, confirms1 = drive(gen1, [ToolConfirmDecision.SESSION])
+    assert confirms1 == 1
+    assert approval.is_allowed("get_weather") is True
+
+    # Turn 2: same tool, same approval manager -> no prompt
+    tc2 = ToolCall(id="c2", name="get_weather", arguments="{}")
+    client2 = make_client(_tool_then_done(tc2), approval)
+    with patch("yaicli.llms.client.execute_tool_call", return_value=("ok", True)) as ex2:
+        gen2 = client2.completion_with_tools([ChatMessage(role="user", content="y")], tool_policy=ToolPolicy(True, True))
+        _, confirms2 = drive(gen2, [])
+    assert confirms2 == 0
+    ex2.assert_called_once()
+
+
+def test_persist_decision_writes_allowlist(tmp_path):
+    path = tmp_path / "p.json"
+    approval = ToolApprovalManager(permissions_path=path)
+    tc = ToolCall(id="c1", name="get_weather", arguments="{}")
+    client = make_client(_tool_then_done(tc), approval)
+
+    with patch("yaicli.llms.client.execute_tool_call", return_value=("ok", True)):
+        gen = client.completion_with_tools([ChatMessage(role="user", content="x")], tool_policy=ToolPolicy(True, True))
+        drive(gen, [ToolConfirmDecision.PERSIST])
+
+    # Persisted and honored by a fresh manager loaded from disk
+    assert ToolApprovalManager(permissions_path=path).is_allowed("get_weather") is True
+
+
+def test_deny_appends_refusal_and_does_not_execute(tmp_path):
+    approval = ToolApprovalManager(permissions_path=tmp_path / "p.json")
+    tc = ToolCall(id="c1", name="get_weather", arguments="{}")
+    client = make_client(_tool_then_done(tc), approval)
+    messages = [ChatMessage(role="user", content="x")]
+
+    with patch("yaicli.llms.client.execute_tool_call") as ex:
+        gen = client.completion_with_tools(messages, tool_policy=ToolPolicy(True, True))
+        drive(gen, [ToolConfirmDecision.DENY])
+
+    ex.assert_not_called()
+    tool_msgs = _tool_messages(messages)
+    assert len(tool_msgs) == 1
+    assert tool_msgs[0].tool_call_id == "c1"
+    assert "declined" in (tool_msgs[0].content or "").lower()
+
+
+def test_deny_mcp_tool_result_name_is_deprefixed(tmp_path):
+    approval = ToolApprovalManager(permissions_path=tmp_path / "p.json")
+    tc = ToolCall(id="c1", name="_mcp__clock", arguments="{}")
+    scripted = [
+        [LLMResponse(tool_call=tc, finish_reason="tool_calls")],
+        [LLMResponse(content="done", finish_reason="stop")],
+    ]
+    client = make_client(scripted, approval)
+    messages = [ChatMessage(role="user", content="x")]
+
+    with patch("yaicli.llms.client.execute_tool_call") as ex:
+        gen = client.completion_with_tools(messages, tool_policy=ToolPolicy(True, True))
+        drive(gen, [ToolConfirmDecision.DENY])
+
+    ex.assert_not_called()
+    tool_msgs = _tool_messages(messages)
+    assert len(tool_msgs) == 1
+    assert tool_msgs[0].tool_call_id == "c1"
+    # MCP prefix stripped, matching the executed path
+    assert tool_msgs[0].name == "clock"
+
+
+def test_multi_tool_turn_denies_one_executes_other(tmp_path):
+    approval = ToolApprovalManager(permissions_path=tmp_path / "p.json")
+    tc1 = ToolCall(id="c1", name="danger", arguments="{}")
+    tc2 = ToolCall(id="c2", name="safe", arguments="{}")
+    scripted = [
+        [
+            LLMResponse(tool_call=tc1, finish_reason="tool_calls"),
+            LLMResponse(tool_call=tc2, finish_reason="tool_calls"),
+        ],
+        [LLMResponse(content="done", finish_reason="stop")],
+    ]
+    client = make_client(scripted, approval)
+    messages = [ChatMessage(role="user", content="x")]
+
+    with patch("yaicli.llms.client.execute_tool_call", return_value=("ok", True)) as ex:
+        gen = client.completion_with_tools(messages, tool_policy=ToolPolicy(True, True))
+        _, confirms = drive(gen, [ToolConfirmDecision.DENY, ToolConfirmDecision.ONCE])
+
+    assert confirms == 2
+    assert ex.call_count == 1  # only the approved call executed
+    # Every tool call has a matching result (so the next request stays valid)
+    assert {m.tool_call_id for m in _tool_messages(messages)} == {"c1", "c2"}
+
+
+def test_non_interactive_denies_unapproved(tmp_path):
+    approval = ToolApprovalManager(permissions_path=tmp_path / "p.json")
+    tc = ToolCall(id="c1", name="get_weather", arguments="{}")
+    client = make_client(_tool_then_done(tc), approval, interactive=False)
+    messages = [ChatMessage(role="user", content="x")]
+
+    with patch("yaicli.llms.client.execute_tool_call") as ex:
+        gen = client.completion_with_tools(messages, tool_policy=ToolPolicy(True, True))
+        _, confirms = drive(gen, [])
+
+    assert confirms == 0  # never prompts without a TTY
+    ex.assert_not_called()
+    tool_msgs = _tool_messages(messages)
+    assert tool_msgs and tool_msgs[0].tool_call_id == "c1"
+
+
+def test_non_interactive_allowlisted_runs(tmp_path):
+    approval = ToolApprovalManager(permissions_path=tmp_path / "p.json")
+    approval.allow_session("get_weather")
+    tc = ToolCall(id="c1", name="get_weather", arguments="{}")
+    client = make_client(_tool_then_done(tc), approval, interactive=False)
+
+    with patch("yaicli.llms.client.execute_tool_call", return_value=("ok", True)) as ex:
+        gen = client.completion_with_tools([ChatMessage(role="user", content="x")], tool_policy=ToolPolicy(True, True))
+        _, confirms = drive(gen, [])
+
+    assert confirms == 0
+    ex.assert_called_once()
+
+
+def test_master_switch_off_executes_without_prompt(tmp_path):
+    approval = ToolApprovalManager(permissions_path=tmp_path / "p.json")
+    tc = ToolCall(id="c1", name="get_weather", arguments="{}")
+    client = make_client(_tool_then_done(tc), approval, tool_confirm=False)
+
+    with patch("yaicli.llms.client.execute_tool_call", return_value=("ok", True)) as ex:
+        gen = client.completion_with_tools([ChatMessage(role="user", content="x")], tool_policy=ToolPolicy(True, True))
+        _, confirms = drive(gen, [])
+
+    assert confirms == 0
+    ex.assert_called_once()

--- a/tests/test_chat_manage.py
+++ b/tests/test_chat_manage.py
@@ -1,3 +1,4 @@
+import json
 import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -372,3 +373,185 @@ class TestFileChatManager:
             # Test that ChatDeleteError is raised when OS prevents file deletion
             with pytest.raises(ChatDeleteError):
                 chat_manager._delete_existing_chat_with_title(chats[0].title)
+
+
+class TestChatModel:
+    """Tests for the Chat dataclass: serialization and file I/O."""
+
+    def test_from_dict_builds_chat_with_history(self):
+        data = {
+            "idx": "1",
+            "title": "T",
+            "date": "2024-01-01T00:00:00",
+            "history": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "yo"}],
+        }
+        chat = Chat.from_dict(data)
+        assert chat.idx == "1"
+        assert chat.title == "T"
+        assert len(chat.history) == 2
+        assert chat.history[0].content == "hi"
+
+    def test_load_returns_false_without_path(self):
+        assert Chat(title="x").load() is False
+
+    def test_load_reads_history_from_file(self, tmp_path):
+        f = tmp_path / "c.json"
+        f.write_text(json.dumps({"title": "T", "date": "d", "history": [{"role": "user", "content": "hi"}]}))
+        chat = Chat(path=f)
+        assert chat.load() is True
+        assert chat.title == "T"
+        assert chat.history[0].content == "hi"
+
+    def test_load_invalid_json_raises(self, tmp_path):
+        f = tmp_path / "c.json"
+        f.write_text("not json")
+        chat = Chat(path=f)
+        with pytest.raises(ChatLoadError):
+            chat.load()
+
+    def test_save_sets_date_when_empty(self, tmp_path):
+        chat = Chat(title="T", date="")
+        chat.add_message("user", "hi")
+        assert chat.save(tmp_path) is True
+        assert chat.date  # populated during save
+        assert chat.path is not None
+
+    def test_save_raises_on_write_error(self, tmp_path):
+        chat = Chat(title="T")
+        chat.add_message("user", "hi")
+        with patch("builtins.open", side_effect=OSError("disk full")):
+            with pytest.raises(ChatSaveError):
+                chat.save(tmp_path)
+
+
+class TestFileChatManagerCoverage:
+    """Additional coverage for FileChatManager branches."""
+
+    def test_post_init_converts_str_path_and_creates_dir(self, tmp_path):
+        sub = tmp_path / "newdir"
+        mgr = FileChatManager(chat_dir=str(sub))
+        assert isinstance(mgr.chat_dir, Path)
+        assert mgr.chat_dir.exists()
+
+    def test_load_chats_parse_error_raises(self, chat_manager):
+        (chat_manager.chat_dir / "20230101-120000-title-X.json").write_text("{}")
+        chat_manager._chats_map = None
+        with patch.object(FileChatManager, "_parse_filename", side_effect=ValueError("boom")):
+            with pytest.raises(ChatLoadError):
+                chat_manager._load_chats()
+
+    def test_new_chat(self, chat_manager):
+        chat = chat_manager.new_chat(title="Fresh")
+        assert chat.title == "Fresh"
+        assert chat_manager.current_chat is chat
+
+    def test_save_chat_uses_current_chat(self, chat_manager):
+        chat = chat_manager.new_chat(title="Cur")
+        chat.add_message("user", "hi")
+        chat_manager.current_chat = chat
+        assert chat_manager.save_chat() == "Cur"
+
+    def test_save_chat_no_chat_raises(self, chat_manager):
+        chat_manager.current_chat = None
+        with pytest.raises(ChatSaveError, match="No chat found"):
+            chat_manager.save_chat()
+
+    def test_delete_existing_chat_empty_title_is_noop(self, chat_manager):
+        chat_manager._delete_existing_chat_with_title("")  # should not raise
+
+    def test_cleanup_old_chats_swallows_unlink_error(self, chat_manager):
+        chat_manager.max_saved_chats = 1
+        (chat_manager.chat_dir / "20230101-120000-title-A.json").write_text("{}")
+        time.sleep(0.01)
+        (chat_manager.chat_dir / "20230102-120000-title-B.json").write_text("{}")
+        with patch.object(Path, "unlink", side_effect=OSError("denied")):
+            chat_manager._cleanup_old_chats()  # error is swallowed
+
+    def test_load_chat_not_exists_returns_empty(self, chat_manager):
+        chat = chat_manager.load_chat("nonexistent_id")
+        assert chat.idx == "nonexistent_id"
+        assert not chat.history
+
+    def test_load_chat_reads_file(self, chat_manager):
+        cid = "myid"
+        data = {"title": "T", "date": "d", "history": [{"role": "user", "content": "hi"}]}
+        (chat_manager.chat_dir / f"{cid}.json").write_text(json.dumps(data))
+        chat = chat_manager.load_chat(cid)
+        assert chat.title == "T"
+        assert chat.history[0].content == "hi"
+        assert chat_manager.current_chat is chat
+
+    def test_load_chat_by_index_path_none_returns_chat(self, chat_manager):
+        chat = Chat(idx="1", title="NoPath", path=None)
+        chat_manager._chats_map = {"index": {"1": chat}, "title": {"NoPath": chat}}
+        assert chat_manager.load_chat_by_index("1") is chat
+
+    def test_load_chat_by_title_path_none_returns_chat(self, chat_manager):
+        chat = Chat(idx="1", title="NoPath", path=None)
+        chat_manager._chats_map = {"index": {"1": chat}, "title": {"NoPath": chat}}
+        assert chat_manager.load_chat_by_title("NoPath") is chat
+
+    def test_delete_chat_not_exists_returns_false(self, chat_manager):
+        assert chat_manager.delete_chat(chat_manager.chat_dir / "ghost.json") is False
+
+    def test_delete_chat_clears_current_chat(self, chat_manager):
+        chat = Chat(title="Del")
+        chat.add_message("user", "hi")
+        chat_manager.save_chat(chat)
+        chat_manager.current_chat = chat
+        assert chat_manager.delete_chat(chat.path) is True
+        assert chat_manager.current_chat is None
+
+    def test_delete_chat_error_raises(self, chat_manager):
+        f = chat_manager.chat_dir / "x.json"
+        f.write_text("{}")
+        with patch.object(Path, "unlink", side_effect=OSError("denied")):
+            with pytest.raises(ChatDeleteError):
+                chat_manager.delete_chat(f)
+
+    def test_delete_chat_by_index_path_none_returns_false(self, chat_manager):
+        chat = Chat(idx="1", title="X", path=None)
+        chat_manager._chats_map = {"index": {"1": chat}, "title": {"X": chat}}
+        assert chat_manager.delete_chat_by_index("1") is False
+
+    def test_delete_chat_by_index_success(self, chat_manager):
+        chat = Chat(title="ByIdx")
+        chat.add_message("user", "hi")
+        chat_manager.save_chat(chat)
+        idx = chat_manager.list_chats()[0].idx
+        assert chat_manager.delete_chat_by_index(idx) is True
+
+    def test_print_chats_empty(self, chat_manager):
+        chat_manager._chats_map = {"index": {}, "title": {}}
+        chat_manager.print_chats()  # prints "No saved chats found"
+
+    def test_print_chats_with_entries(self, chat_manager):
+        empty_date = Chat(idx="1", title="P", date="", path=None)
+        iso_date = Chat(idx="2", title="Q", date="2023-01-01T12:00:00", path=None)
+        chat_manager._chats_map = {
+            "index": {"1": empty_date, "2": iso_date},
+            "title": {"P": empty_date, "Q": iso_date},
+        }
+        chat_manager.print_chats()  # builds table over both date branches
+
+
+class TestPrintListOption:
+    """Tests for the print_list_option typer callback."""
+
+    def test_falsy_value_returns_without_exit(self):
+        assert FileChatManager.print_list_option(False) is False
+
+    def test_no_chats(self):
+        import typer
+
+        with patch("yaicli.chat.FileChatManager.list_chats", return_value=[]):
+            with pytest.raises(typer.Exit):
+                FileChatManager.print_list_option(True)
+
+    def test_with_chats(self):
+        import typer
+
+        chat = Chat(idx="1", title="L", date="2023-01-01T12:00:00")
+        with patch("yaicli.chat.FileChatManager.list_chats", return_value=[chat]):
+            with pytest.raises(typer.Exit):
+                FileChatManager.print_list_option(True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -903,3 +903,338 @@ class TestSystemPrompt:
         # Should be different from chat mode prompt
         assert "EXCLUSIVELY" in expected_prompt
         assert "Shell Command Generator" in expected_prompt
+
+
+class TestCLICoverage:
+    """Cover remaining CLI branches not exercised elsewhere."""
+
+    def test_set_role_coder_disables_markdown(self, cli_with_mocks):
+        cli_with_mocks.set_role(DefaultRoleNames.CODER)
+        assert cli_with_mocks.printer.content_markdown is False
+
+    def test_evaluate_role_name_code(self):
+        assert CLI.evaluate_role_name(code=True) == DefaultRoleNames.CODER
+
+    def test_evaluate_role_name_default(self):
+        assert CLI.evaluate_role_name() == DefaultRoleNames.DEFAULT
+
+    def test_check_history_len_trims_with_verbose(self, cli_with_mocks):
+        from yaicli.schemas import ChatMessage
+
+        cli_with_mocks.verbose = True
+        cli_with_mocks.interactive_round = 2  # target_len = 4
+        cli_with_mocks.chat.history = [ChatMessage(role="user", content=str(i)) for i in range(6)]
+        cli_with_mocks._check_history_len()
+        assert len(cli_with_mocks.chat.history) == 4
+        printed = [str(c.args[0]) for c in cli_with_mocks.console.print.call_args_list]
+        assert any("trimmed" in t.lower() for t in printed)
+
+    def test_save_chat_error_handled(self, cli_with_mocks):
+        from unittest.mock import MagicMock
+
+        from yaicli.exceptions import ChatSaveError
+
+        cli_with_mocks.chat.history = [MagicMock()]
+        cli_with_mocks.chat_manager.save_chat.side_effect = ChatSaveError("boom")
+        cli_with_mocks._save_chat("T")
+        printed = [str(c.args[0]) for c in cli_with_mocks.console.print.call_args_list]
+        assert any("Failed to save chat" in t for t in printed)
+
+    def test_list_chats_without_date(self, cli_with_mocks):
+        from unittest.mock import MagicMock
+
+        chat = MagicMock()
+        chat.idx = "1"
+        chat.title = "T"
+        chat.date = ""
+        cli_with_mocks.chat_manager.list_chats.return_value = [chat]
+        cli_with_mocks._list_chats()
+        printed = [str(c.args[0]) for c in cli_with_mocks.console.print.call_args_list]
+        assert any("T" in t for t in printed)
+
+    def test_refresh_chats(self, cli_with_mocks):
+        cli_with_mocks._refresh_chats()
+        cli_with_mocks.chat_manager.refresh_chats.assert_called_once()
+
+    def test_load_chat_by_index_not_found(self, cli_with_mocks):
+        cli_with_mocks.chat_manager.validate_chat_index.return_value = True
+        cli_with_mocks.chat_manager.load_chat_by_index.return_value = None
+        assert cli_with_mocks._load_chat_by_index("1") is False
+        printed = [str(c.args[0]) for c in cli_with_mocks.console.print.call_args_list]
+        assert any("not found" in t for t in printed)
+
+    def test_delete_chat_by_index_invalid(self, cli_with_mocks):
+        cli_with_mocks.chat_manager.validate_chat_index.return_value = False
+        assert cli_with_mocks._delete_chat_by_index("999") is False
+
+    def test_delete_chat_by_index_not_found(self, cli_with_mocks):
+        cli_with_mocks.chat_manager.validate_chat_index.return_value = True
+        cli_with_mocks.chat_manager.load_chat_by_index.return_value = None
+        assert cli_with_mocks._delete_chat_by_index("1") is False
+
+    def test_delete_chat_by_index_no_path(self, cli_with_mocks):
+        from unittest.mock import MagicMock
+
+        chat = MagicMock()
+        chat.path = None
+        chat.title = "T"
+        cli_with_mocks.chat_manager.validate_chat_index.return_value = True
+        cli_with_mocks.chat_manager.load_chat_by_index.return_value = chat
+        assert cli_with_mocks._delete_chat_by_index("1") is False
+        printed = [str(c.args[0]) for c in cli_with_mocks.console.print.call_args_list]
+        assert any("no associated file" in t for t in printed)
+
+    def test_delete_chat_by_index_delete_fails(self, cli_with_mocks):
+        from unittest.mock import MagicMock
+
+        chat = MagicMock()
+        chat.path = Path("/tmp/x.json")
+        chat.title = "T"
+        cli_with_mocks.chat_manager.validate_chat_index.return_value = True
+        cli_with_mocks.chat_manager.load_chat_by_index.return_value = chat
+        cli_with_mocks.chat_manager.delete_chat.return_value = False
+        assert cli_with_mocks._delete_chat_by_index("1") is False
+        printed = [str(c.args[0]) for c in cli_with_mocks.console.print.call_args_list]
+        assert any("Failed to delete" in t for t in printed)
+
+    def test_delete_chat_by_index_success(self, cli_with_mocks):
+        from unittest.mock import MagicMock
+
+        chat = MagicMock()
+        chat.path = Path("/tmp/x.json")
+        chat.title = "T"
+        cli_with_mocks.chat_manager.validate_chat_index.return_value = True
+        cli_with_mocks.chat_manager.load_chat_by_index.return_value = chat
+        cli_with_mocks.chat_manager.delete_chat.return_value = True
+        assert cli_with_mocks._delete_chat_by_index("1") is True
+
+    def test_build_messages_with_context_and_at_refs(self, cli_with_mocks):
+        from unittest.mock import MagicMock
+
+        from yaicli.schemas import ChatMessage
+
+        cli_with_mocks.context_manager = MagicMock()
+        cli_with_mocks.context_manager.get_context_messages.return_value = [
+            ChatMessage(role="system", content="ctx")
+        ]
+        cli_with_mocks.context_manager.parse_at_references.return_value = ("at refs", "cleaned", [])
+        messages = cli_with_mocks._build_messages("hello @f.txt")
+        contents = [m.content for m in messages]
+        assert "ctx" in contents
+        assert "at refs" in contents
+
+    def test_handle_llm_response_error_verbose(self, cli_with_mocks):
+        from unittest.mock import MagicMock, patch
+
+        cli_with_mocks.verbose = True
+        cli_with_mocks.context_manager = MagicMock()
+        cli_with_mocks.context_manager.get_context_messages.return_value = []
+        cli_with_mocks.context_manager.parse_at_references.return_value = ("", "hi", [])
+        cli_with_mocks.client.completion_with_tools.side_effect = RuntimeError("boom")
+        with patch("yaicli.cli.traceback.print_exc") as mock_tb:
+            content, _ = cli_with_mocks._handle_llm_response("hi")
+        assert content is None
+        mock_tb.assert_called_once()
+
+    def test_process_user_input_exec_mode_executes(self, cli_with_mocks):
+        from unittest.mock import MagicMock, patch
+
+        cli_with_mocks.current_mode = EXEC_MODE
+        cli_with_mocks.printer = MagicMock()
+        cli_with_mocks.printer.display_stream.return_value = ("ls -la", "")
+        cli_with_mocks.context_manager = MagicMock()
+        cli_with_mocks.context_manager.get_context_messages.return_value = []
+        cli_with_mocks.context_manager.parse_at_references.return_value = ("", "ls", [])
+        with (
+            patch("yaicli.cli.filter_command", return_value="ls -la"),
+            patch("yaicli.cli.Prompt.ask", return_value="n"),
+        ):
+            assert cli_with_mocks._process_user_input("ls") is True
+
+    def test_confirm_and_execute_edit_changed(self, cli_with_mocks):
+        from unittest.mock import patch
+
+        with (
+            patch("yaicli.cli.filter_command", return_value="ls"),
+            patch("yaicli.cli.Prompt.ask", return_value="e"),
+            patch("yaicli.cli.prompt", return_value="ls -la"),
+            patch("yaicli.cli.subprocess.call") as mock_call,
+        ):
+            cli_with_mocks._confirm_and_execute("ls")
+            mock_call.assert_called_once_with("ls -la", shell=True)
+
+    def test_confirm_and_execute_edit_unchanged(self, cli_with_mocks):
+        from unittest.mock import patch
+
+        with (
+            patch("yaicli.cli.filter_command", return_value="ls"),
+            patch("yaicli.cli.Prompt.ask", return_value="e"),
+            patch("yaicli.cli.prompt", return_value="ls"),
+            patch("yaicli.cli.subprocess.call") as mock_call,
+        ):
+            cli_with_mocks._confirm_and_execute("ls")
+            mock_call.assert_called_once_with("ls", shell=True)
+
+    def test_confirm_and_execute_edit_empty_cancels(self, cli_with_mocks):
+        from unittest.mock import patch
+
+        with (
+            patch("yaicli.cli.filter_command", return_value="ls"),
+            patch("yaicli.cli.Prompt.ask", return_value="e"),
+            patch("yaicli.cli.prompt", return_value="  "),
+            patch("yaicli.cli.subprocess.call") as mock_call,
+        ):
+            cli_with_mocks._confirm_and_execute("ls")
+            mock_call.assert_not_called()
+
+    def test_confirm_and_execute_edit_eoferror(self, cli_with_mocks):
+        from unittest.mock import patch
+
+        with (
+            patch("yaicli.cli.filter_command", return_value="ls"),
+            patch("yaicli.cli.Prompt.ask", return_value="e"),
+            patch("yaicli.cli.prompt", side_effect=EOFError),
+            patch("yaicli.cli.subprocess.call") as mock_call,
+        ):
+            cli_with_mocks._confirm_and_execute("ls")
+            mock_call.assert_not_called()
+        printed = [str(c.args[0]) for c in cli_with_mocks.console.print.call_args_list]
+        assert any("Edit cancelled" in t for t in printed)
+
+    def test_confirm_and_execute_subprocess_error(self, cli_with_mocks):
+        from unittest.mock import patch
+
+        with (
+            patch("yaicli.cli.filter_command", return_value="ls"),
+            patch("yaicli.cli.Prompt.ask", return_value="y"),
+            patch("yaicli.cli.subprocess.call", side_effect=OSError("boom")),
+        ):
+            cli_with_mocks._confirm_and_execute("ls")
+        printed = [str(c.args[0]) for c in cli_with_mocks.console.print.call_args_list]
+        assert any("Failed to execute command" in t for t in printed)
+
+    def test_confirm_and_execute_empty_command(self, cli_with_mocks):
+        from unittest.mock import patch
+
+        with patch("yaicli.cli.filter_command", return_value=""):
+            cli_with_mocks._confirm_and_execute("garbage")
+        printed = [str(c.args[0]) for c in cli_with_mocks.console.print.call_args_list]
+        assert any("No command generated" in t for t in printed)
+
+    def test_prepare_chat_loop_session_error_falls_back(self, cli_with_mocks):
+        from unittest.mock import MagicMock, patch
+
+        with (
+            patch("yaicli.cli.HISTORY_FILE", MagicMock()),
+            patch("yaicli.cli.PromptSession", side_effect=[Exception("boom"), MagicMock()]),
+        ):
+            cli_with_mocks.prepare_chat_loop()
+        printed = [str(c.args[0]) for c in cli_with_mocks.console.print.call_args_list]
+        assert any("Error initializing prompt session" in t for t in printed)
+
+    def test_setup_key_bindings_toggles_mode(self, cli_with_mocks):
+        from unittest.mock import MagicMock
+
+        cli_with_mocks.current_mode = CHAT_MODE
+        cli_with_mocks._setup_key_bindings()
+        binding = cli_with_mocks.bindings.bindings[-1]
+        binding.handler(MagicMock())
+        assert cli_with_mocks.current_mode == EXEC_MODE
+
+    def test_print_welcome_persistent_session(self, cli_with_mocks):
+        cli_with_mocks.is_temp_session = False
+        cli_with_mocks.chat.title = "MyChat"
+        cli_with_mocks._print_welcome_message()
+        printed = [str(c.args[0]) for c in cli_with_mocks.console.print.call_args_list if c.args]
+        assert any("Persistent Session" in t for t in printed)
+
+    def test_run_repl_empty_then_command_then_exit(self, cli_with_mocks):
+        from unittest.mock import MagicMock, patch
+
+        mock_session = MagicMock()
+        mock_session.prompt.side_effect = ["", "/help", "/exit"]
+        with (
+            patch("yaicli.cli.PromptSession", return_value=mock_session),
+            patch("yaicli.cli.HISTORY_FILE", MagicMock()),
+            patch("yaicli.cli.AtPathCompleter"),
+            patch("yaicli.cli.LimitedFileHistory"),
+        ):
+            cli_with_mocks._run_repl()
+
+    def test_run_repl_process_input_and_keyboard_interrupt(self, cli_with_mocks):
+        from unittest.mock import MagicMock, patch
+
+        mock_session = MagicMock()
+        mock_session.prompt.side_effect = ["hello", EOFError()]
+        cli_with_mocks.client.completion_with_tools.side_effect = KeyboardInterrupt
+        with (
+            patch("yaicli.cli.PromptSession", return_value=mock_session),
+            patch("yaicli.cli.HISTORY_FILE", MagicMock()),
+            patch("yaicli.cli.AtPathCompleter"),
+            patch("yaicli.cli.LimitedFileHistory"),
+        ):
+            cli_with_mocks._run_repl()
+        printed = [str(c.args[0]) for c in cli_with_mocks.console.print.call_args_list if c.args]
+        assert any("KeyboardInterrupt" in t for t in printed)
+
+    def test_run_repl_autosave_on_exit(self, cli_with_mocks):
+        from unittest.mock import MagicMock, patch
+
+        mock_session = MagicMock()
+        mock_session.prompt.side_effect = EOFError()
+        cli_with_mocks.is_temp_session = False
+        cli_with_mocks.chat.history = [MagicMock()]
+        cli_with_mocks.chat.title = "T"
+        with (
+            patch("yaicli.cli.PromptSession", return_value=mock_session),
+            patch("yaicli.cli.HISTORY_FILE", MagicMock()),
+            patch("yaicli.cli.AtPathCompleter"),
+            patch("yaicli.cli.LimitedFileHistory"),
+        ):
+            cli_with_mocks._run_repl()
+        cli_with_mocks.chat_manager.save_chat.assert_called()
+
+    def test_create_client_yaicli_error_aborts(self, cli_with_mocks):
+        from unittest.mock import patch
+
+        from yaicli.exceptions import YaicliError
+
+        with (
+            patch("yaicli.cli.LLMClient", side_effect=YaicliError("boom")),
+            patch("yaicli.cli.ToolApprovalManager"),
+        ):
+            with pytest.raises(typer.Abort):
+                cli_with_mocks._create_client()
+        printed = [str(c.args[0]) for c in cli_with_mocks.console.print.call_args_list]
+        assert any("Error creating client" in t for t in printed)
+
+    def test_evaluate_role_name_explicit_role(self):
+        assert CLI.evaluate_role_name(role="custom-role") == "custom-role"
+
+    def test_process_user_input_no_content_returns_true(self, cli_with_mocks):
+        from unittest.mock import patch
+
+        with patch.object(CLI, "_handle_llm_response", return_value=(None, [])):
+            assert cli_with_mocks._process_user_input("hi") is True
+
+    def test_build_messages_images_no_vision_provider(self, cli_with_mocks):
+        from unittest.mock import MagicMock, patch
+
+        from yaicli.const import NO_VISION_PROVIDERS
+        from yaicli.schemas import ImageData
+
+        if not NO_VISION_PROVIDERS:
+            pytest.skip("No no-vision providers configured")
+
+        cli_with_mocks.context_manager = MagicMock()
+        cli_with_mocks.context_manager.get_context_messages.return_value = []
+        cli_with_mocks.context_manager.parse_at_references.return_value = ("", "hi", [])
+        no_vision = next(iter(NO_VISION_PROVIDERS))
+        img = ImageData(data="x", media_type="image/png", is_url=False)
+        with patch("yaicli.cli.cfg") as mock_cfg:
+            mock_cfg.get.side_effect = lambda k, d=None: no_vision if k == "PROVIDER" else d
+            messages = cli_with_mocks._build_messages("hi", images=[img])
+
+        printed = [str(c.args[0]) for c in cli_with_mocks.console.print.call_args_list if c.args]
+        assert any("does not support image" in t for t in printed)
+        assert messages[-1].images == []

--- a/tests/test_command_handler.py
+++ b/tests/test_command_handler.py
@@ -195,3 +195,113 @@ class TestCmdHandler:
         """Test handling non-special command."""
         result = cmd_handler.handle_command("hello world")
         assert result == "hello world"  # Should return the original input
+
+
+class TestHandleAddContext:
+    """Tests for handle_add_context."""
+
+    def test_shlex_error(self, cmd_handler):
+        result = cmd_handler.handle_add_context('/add "unclosed')
+        assert result is True
+        printed = [str(c.args[0]) for c in cmd_handler.cli.console.print.call_args_list]
+        assert any("Error parsing command" in t for t in printed)
+        cmd_handler.cli.context_manager.add.assert_not_called()
+
+    def test_missing_path(self, cmd_handler):
+        result = cmd_handler.handle_add_context("/add")
+        assert result is True
+        printed = [str(c.args[0]) for c in cmd_handler.cli.console.print.call_args_list]
+        assert any("Usage:" in t for t in printed)
+        cmd_handler.cli.context_manager.add.assert_not_called()
+
+    def test_add_path_not_verbose(self, cmd_handler):
+        cmd_handler.cli.verbose = False
+        result = cmd_handler.handle_add_context("/add myfile.txt")
+        assert result is True
+        cmd_handler.cli.context_manager.add.assert_called_once_with("myfile.txt")
+
+    def test_add_path_with_at_and_verbose(self, cmd_handler):
+        cmd_handler.cli.verbose = True
+        result = cmd_handler.handle_add_context("/add @myfile.txt")
+        assert result is True
+        cmd_handler.cli.context_manager.add.assert_called_once_with("myfile.txt")
+        printed = [str(c.args[0]) for c in cmd_handler.cli.console.print.call_args_list]
+        assert any("Adding context" in t for t in printed)
+
+
+class TestHandleContext:
+    """Tests for handle_context subcommands."""
+
+    def test_shlex_error(self, cmd_handler):
+        result = cmd_handler.handle_context('/context "unclosed')
+        assert result is True
+        printed = [str(c.args[0]) for c in cmd_handler.cli.console.print.call_args_list]
+        assert any("Error parsing command" in t for t in printed)
+
+    def test_no_subcommand_defaults_to_list(self, cmd_handler):
+        result = cmd_handler.handle_context("/context")
+        assert result is True
+        cmd_handler.cli.context_manager.list_items.assert_called_once()
+
+    def test_list(self, cmd_handler):
+        result = cmd_handler.handle_context("/context list")
+        assert result is True
+        cmd_handler.cli.context_manager.list_items.assert_called_once()
+
+    def test_clear(self, cmd_handler):
+        result = cmd_handler.handle_context("/context clear")
+        assert result is True
+        cmd_handler.cli.context_manager.clear.assert_called_once()
+
+    def test_add_missing_path(self, cmd_handler):
+        result = cmd_handler.handle_context("/context add")
+        assert result is True
+        printed = [str(c.args[0]) for c in cmd_handler.cli.console.print.call_args_list]
+        assert any("Usage: /context add" in t for t in printed)
+        cmd_handler.cli.context_manager.add.assert_not_called()
+
+    def test_add_with_at_prefix(self, cmd_handler):
+        result = cmd_handler.handle_context("/context add @f.txt")
+        assert result is True
+        cmd_handler.cli.context_manager.add.assert_called_once_with("f.txt")
+
+    def test_remove_missing_path(self, cmd_handler):
+        result = cmd_handler.handle_context("/context remove")
+        assert result is True
+        printed = [str(c.args[0]) for c in cmd_handler.cli.console.print.call_args_list]
+        assert any("Usage: /context remove" in t for t in printed)
+        cmd_handler.cli.context_manager.remove.assert_not_called()
+
+    def test_remove_path(self, cmd_handler):
+        result = cmd_handler.handle_context("/context remove f.txt")
+        assert result is True
+        cmd_handler.cli.context_manager.remove.assert_called_once_with("f.txt")
+
+    def test_remove_alias_rm(self, cmd_handler):
+        result = cmd_handler.handle_context("/context rm f.txt")
+        assert result is True
+        cmd_handler.cli.context_manager.remove.assert_called_once_with("f.txt")
+
+    def test_unknown_subcommand(self, cmd_handler):
+        result = cmd_handler.handle_context("/context bogus")
+        assert result is True
+        printed = [str(c.args[0]) for c in cmd_handler.cli.console.print.call_args_list]
+        assert any("Unknown sub-command" in t for t in printed)
+
+
+class TestHandleHistoryToolCalls:
+    """Test history rendering for assistant messages carrying tool calls."""
+
+    def test_history_with_tool_calls(self, cmd_handler):
+        tool_call = MagicMock()
+        tool_call.name = "get_weather"
+        tool_call.arguments = '{"city": "NYC"}'
+        assistant_msg = MagicMock(role="assistant", content="Let me check", tool_calls=[tool_call])
+        cmd_handler.cli.chat.history = [assistant_msg]
+
+        with patch("yaicli.cmd_handler.cfg", {"CODE_THEME": "monokai"}):
+            result = cmd_handler.handle_history()
+
+        assert result is True
+        printed = [str(c.args[0]) for c in cmd_handler.cli.console.print.call_args_list]
+        assert any("Assistant:" in t for t in printed)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from yaicli.context import ContextManager
@@ -259,3 +262,134 @@ def test_parse_at_references_unreadable_image(context_manager, temp_workspace):
         if sys.platform != "win32":
             img.chmod(0o644)
         os.chdir(original_cwd)
+
+
+def test_get_context_messages_empty(context_manager):
+    """get_context_messages returns an empty list when there is no context."""
+    assert context_manager.get_context_messages() == []
+
+
+def test_add_already_in_context(context_manager, temp_workspace):
+    """Adding the same path twice reports it is already present."""
+    file_path = temp_workspace / "file1.txt"
+    assert context_manager.add(str(file_path)) is True
+    assert context_manager.add(str(file_path)) is True
+    assert len(context_manager.items) == 1
+
+
+def test_add_unsupported_path_type(context_manager, tmp_path):
+    """A path that exists but is neither file nor dir (FIFO) is unsupported."""
+    import os
+    import sys
+
+    if sys.platform == "win32":
+        pytest.skip("mkfifo not supported on Windows")
+    fifo = tmp_path / "myfifo"
+    os.mkfifo(str(fifo))
+    assert context_manager.add(str(fifo)) is False
+
+
+def test_remove_multiple_matches(context_manager, temp_workspace):
+    """Removing an ambiguous partial name reports multiple matches and aborts."""
+    context_manager.add(str(temp_workspace / "file1.txt"))
+    context_manager.add(str(temp_workspace / "file2.py"))
+    assert context_manager.remove("file") is False
+    assert len(context_manager.items) == 2
+
+
+def test_remove_not_found(context_manager, temp_workspace):
+    """Removing a name that matches nothing returns False."""
+    context_manager.add(str(temp_workspace / "file1.txt"))
+    assert context_manager.remove("nonexistent.xyz") is False
+
+
+def test_list_items_empty(context_manager):
+    """list_items prints an empty notice when there are no items."""
+    with patch("yaicli.context.console", MagicMock()) as console:
+        context_manager.list_items()
+    printed = [str(c.args[0]) for c in console.print.call_args_list]
+    assert any("Context is empty" in t for t in printed)
+
+
+def test_list_items_outside_cwd(context_manager, temp_workspace):
+    """list_items renders items whose path is not relative to cwd (ValueError branch)."""
+    context_manager.add(str(temp_workspace / "file1.txt"))
+    context_manager.list_items()
+    assert len(context_manager.items) == 1
+
+
+def test_list_items_relative_path(context_manager, tmp_path, monkeypatch):
+    """When an item lives under cwd, list_items shows it as a relative path."""
+    monkeypatch.chdir(tmp_path)
+    f = tmp_path / "rel.txt"
+    f.write_text("x")
+    context_manager.add(str(f))
+    context_manager.list_items()
+    assert len(context_manager.items) == 1
+
+
+def test_read_file_binary_omitted(context_manager, tmp_path):
+    """_read_file returns a placeholder for known binary suffixes."""
+    pdf = tmp_path / "doc.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    assert context_manager._read_file(Path(str(pdf))) == "[Binary file omitted]"
+
+
+def test_read_file_too_large(context_manager, tmp_path):
+    """_read_file omits files larger than 1MB."""
+    big = tmp_path / "big.txt"
+    big.write_text("a" * 1_000_001)
+    result = context_manager._read_file(Path(str(big)))
+    assert "File too large" in result
+
+
+def test_read_file_error(context_manager, tmp_path):
+    """_read_file catches read errors and returns an error string."""
+    target = tmp_path / "ghost.txt"
+    target.write_text("x")
+    with patch("builtins.open", side_effect=OSError("boom")):
+        result = context_manager._read_file(Path(str(target)))
+    assert "Error reading file" in result
+
+
+def test_read_dir_recursive_depth_limit(context_manager, tmp_path):
+    """Recursion stops immediately when current_depth exceeds max_depth."""
+    content = []
+    context_manager._read_dir_recursive(Path(str(tmp_path)), content, current_depth=3, max_depth=2)
+    assert content == []
+
+
+def test_read_dir_recursive_skips_hidden_and_ignored(context_manager, tmp_path):
+    """Hidden files and default-ignored directories are skipped while reading."""
+    (tmp_path / "visible.txt").write_text("hi")
+    (tmp_path / ".hidden.txt").write_text("secret")
+    ignored = tmp_path / "__pycache__"
+    ignored.mkdir()
+    (ignored / "cache.py").write_text("x")
+
+    content = []
+    context_manager._read_dir_recursive(Path(str(tmp_path)), content, 0, 2)
+    joined = "\n".join(content)
+    assert "visible.txt" in joined
+    assert ".hidden.txt" not in joined
+    assert "cache.py" not in joined
+
+
+def test_read_dir_recursive_scan_error(context_manager):
+    """An error while scanning a directory is caught and reported."""
+    bad_dir = MagicMock(spec=Path)
+    bad_dir.iterdir.side_effect = PermissionError("denied")
+    content = []
+    context_manager._read_dir_recursive(bad_dir, content, 0, 2)  # should not raise
+    assert content == []
+
+
+def test_parse_at_references_outer_exception(context_manager, tmp_path, monkeypatch):
+    """An unexpected error while processing a reference is caught by the outer try."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "f.txt").write_text("x")
+    with patch.object(context_manager, "_read_file", side_effect=RuntimeError("boom")):
+        at_content, cleaned, images = context_manager.parse_at_references("Check @f.txt")
+    # Reference left intact because processing raised before the replacement
+    assert "@f.txt" in cleaned
+    assert images == []

--- a/tests/test_functions_init.py
+++ b/tests/test_functions_init.py
@@ -1,0 +1,157 @@
+"""Tests for yaicli.functions package CLI callbacks (install/reinstall/print)."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+
+from yaicli.functions import (
+    install_functions,
+    print_functions,
+    print_mcp,
+    reinstall_functions,
+)
+
+
+class TestInstallFunctions:
+    """Tests for install_functions."""
+
+    def test_install_copies_buildin(self, tmp_path):
+        """install_functions copies builtin .py files into a fresh FUNCTIONS_DIR."""
+        functions_dir = tmp_path / "funcs"
+        console = MagicMock()
+        with (
+            patch("yaicli.functions.FUNCTIONS_DIR", functions_dir),
+            patch("yaicli.functions.console", console),
+        ):
+            with pytest.raises(typer.Exit):
+                install_functions(None, True)
+
+        copied = list(functions_dir.glob("*.py"))
+        assert copied
+        printed = [str(c.args[0]) for c in console.print.call_args_list]
+        assert any("Installing buildin functions" in t for t in printed)
+        assert any("Installed" in t for t in printed)
+
+    def test_install_skips_existing(self, tmp_path):
+        """A second install skips files that already exist."""
+        functions_dir = tmp_path / "funcs"
+        console = MagicMock()
+        with (
+            patch("yaicli.functions.FUNCTIONS_DIR", functions_dir),
+            patch("yaicli.functions.console", console),
+        ):
+            with pytest.raises(typer.Exit):
+                install_functions(None, True)
+            console.reset_mock()
+            with pytest.raises(typer.Exit):
+                install_functions(None, True)
+
+        printed = [str(c.args[0]) for c in console.print.call_args_list]
+        assert any("already exists, skipping" in t for t in printed)
+
+
+class TestReinstallFunctions:
+    """Tests for reinstall_functions."""
+
+    def test_reinstall_into_empty_dir(self, tmp_path):
+        """reinstall into an empty dir creates it and copies builtin files."""
+        functions_dir = tmp_path / "funcs"
+        console = MagicMock()
+        with (
+            patch("yaicli.functions.FUNCTIONS_DIR", functions_dir),
+            patch("yaicli.functions.console", console),
+        ):
+            with pytest.raises(typer.Exit):
+                reinstall_functions(None, True)
+
+        assert list(functions_dir.glob("*.py"))
+        printed = [str(c.args[0]) for c in console.print.call_args_list]
+        assert any("Reinstalling builtin functions" in t for t in printed)
+        assert any("Reinstalled" in t for t in printed)
+
+    def test_reinstall_overwrites_existing(self, tmp_path):
+        """reinstall removes and re-copies files that already exist."""
+        functions_dir = tmp_path / "funcs"
+        console = MagicMock()
+        with (
+            patch("yaicli.functions.FUNCTIONS_DIR", functions_dir),
+            patch("yaicli.functions.console", console),
+        ):
+            with pytest.raises(typer.Exit):
+                install_functions(None, True)
+            console.reset_mock()
+            with pytest.raises(typer.Exit):
+                reinstall_functions(None, True)
+
+        printed = [str(c.args[0]) for c in console.print.call_args_list]
+        assert any("Reinstalled" in t for t in printed)
+
+
+class TestPrintFunctions:
+    """Tests for print_functions."""
+
+    def test_no_functions_dir(self, tmp_path):
+        """Reports when no functions directory exists."""
+        functions_dir = tmp_path / "missing"
+        console = MagicMock()
+        with (
+            patch("yaicli.functions.FUNCTIONS_DIR", functions_dir),
+            patch("yaicli.functions.console", console),
+        ):
+            with pytest.raises(typer.Exit):
+                print_functions(None, True)
+
+        printed = [str(c.args[0]) for c in console.print.call_args_list]
+        assert any("No installed functions found" in t for t in printed)
+
+    def test_lists_functions_skips_underscore(self, tmp_path):
+        """Lists .py files but skips those starting with underscore."""
+        functions_dir = tmp_path / "funcs"
+        functions_dir.mkdir()
+        (functions_dir / "visible.py").write_text("x")
+        (functions_dir / "_hidden.py").write_text("x")
+        console = MagicMock()
+        with (
+            patch("yaicli.functions.FUNCTIONS_DIR", functions_dir),
+            patch("yaicli.functions.console", console),
+        ):
+            with pytest.raises(typer.Exit):
+                print_functions(None, True)
+
+        printed = [str(c.args[0]) for c in console.print.call_args_list]
+        assert any("visible.py" in t for t in printed)
+        assert not any("_hidden.py" in t for t in printed)
+
+
+class TestPrintMcp:
+    """Tests for print_mcp."""
+
+    def test_no_mcp_config(self, tmp_path):
+        """Reports when no MCP config file exists."""
+        mcp_path = tmp_path / "mcp.json"
+        console = MagicMock()
+        with (
+            patch("yaicli.functions.MCP_JSON_PATH", mcp_path),
+            patch("yaicli.functions.console", console),
+        ):
+            with pytest.raises(typer.Exit):
+                print_mcp(None, True)
+
+        printed = [str(c.args[0]) for c in console.print.call_args_list]
+        assert any("No mcp config found" in t for t in printed)
+
+    def test_prints_mcp_config(self, tmp_path):
+        """Prints the MCP config JSON when the file exists."""
+        mcp_path = tmp_path / "mcp.json"
+        mcp_path.write_text(json.dumps({"servers": {"a": 1}}))
+        console = MagicMock()
+        with (
+            patch("yaicli.functions.MCP_JSON_PATH", mcp_path),
+            patch("yaicli.functions.console", console),
+        ):
+            with pytest.raises(typer.Exit):
+                print_mcp(None, True)
+
+        console.print_json.assert_called_once()

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -1,10 +1,11 @@
 import unittest
+from io import StringIO
 from unittest.mock import MagicMock, patch
 
-from rich.console import Group
+from rich.console import Console, Group
 
 from yaicli.printer import Printer
-from yaicli.schemas import ChatMessage
+from yaicli.schemas import ConfirmToolCall, LLMResponse, RefreshLive, ToolCall, ToolConfirmDecision
 
 
 class TestPrinter(unittest.TestCase):
@@ -33,6 +34,51 @@ class TestPrinter(unittest.TestCase):
         self.assertEqual(self.printer.show_reasoning, True)
         self.assertTrue(self.printer.content_markdown)
         self.assertFalse(self.printer.in_reasoning)
+
+    def test_confirm_tool_call_maps_choices(self):
+        """Each keypress maps to the matching ToolConfirmDecision."""
+        tc = ToolCall(id="c1", name="get_weather", arguments="{}")
+        cases = {
+            "y": ToolConfirmDecision.ONCE,
+            "a": ToolConfirmDecision.SESSION,
+            "A": ToolConfirmDecision.PERSIST,
+            "n": ToolConfirmDecision.DENY,
+        }
+        for key, expected in cases.items():
+            with patch("yaicli.printer.Prompt.ask", return_value=key):
+                self.assertEqual(self.printer._confirm_tool_call(tc), expected)
+
+    def test_confirm_tool_call_keyboard_interrupt_denies(self):
+        """Ctrl-C at the prompt is treated as deny, not propagated."""
+        tc = ToolCall(id="c1", name="get_weather", arguments="{}")
+        with patch("yaicli.printer.Prompt.ask", side_effect=KeyboardInterrupt):
+            self.assertEqual(self.printer._confirm_tool_call(tc), ToolConfirmDecision.DENY)
+
+    def test_confirm_tool_call_eof_denies(self):
+        """EOF (no input stream) at the prompt is treated as deny."""
+        tc = ToolCall(id="c1", name="get_weather", arguments="{}")
+        with patch("yaicli.printer.Prompt.ask", side_effect=EOFError):
+            self.assertEqual(self.printer._confirm_tool_call(tc), ToolConfirmDecision.DENY)
+
+    def test_display_stream_streams_reasoning_once(self):
+        """Reasoning is emitted append-only (header once, no per-frame re-render)."""
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=False, width=80)
+        printer = Printer(console=console)
+        printer.show_reasoning = True
+
+        def gen():
+            yield LLMResponse(reasoning="line one\n")
+            yield LLMResponse(reasoning="line two\n")
+            yield LLMResponse(content="The answer")
+
+        printer.display_stream(gen())
+        out = buf.getvalue()
+        # Header printed exactly once, both reasoning lines present, content rendered.
+        self.assertEqual(out.count("Thinking:"), 1)
+        self.assertIn("line one", out)
+        self.assertIn("line two", out)
+        self.assertIn("The answer", out)
 
     def test_reset_state(self):
         """Test _reset_state method properly resets printer state."""
@@ -136,93 +182,119 @@ class TestPrinter(unittest.TestCase):
         self.printer.content_formatter.assert_called_once()
         self.printer.reasoning_formatter.assert_called_once()
 
-    def test_display_normal(self):
-        """Test display_normal method with LLMContent."""
-        # Create mock messages list
-        messages = []
+    def test_process_chunk_in_reasoning_appends_content(self):
+        """When in reasoning mode, chunk content is appended to reasoning, not content."""
+        self.printer.in_reasoning = True
+        content, reasoning = self.printer._process_chunk("more thinking", "", "", "existing ")
+        self.assertEqual(content, "")
+        self.assertEqual(reasoning, "existing more thinking")
 
-        # Create a simplified version of display_normal for testing
-        def mock_display_normal(iterator, msgs):
-            # Simulate what display_normal does without LLMContent dependency
-            self.printer._reset_state()
-            full_content = "Hello World"
-            full_reasoning = "thinking"
+    def test_format_display_text_empty_returns_empty_string(self):
+        """No content and no reasoning yields an empty string."""
+        result = self.printer._format_display_text("", "")
+        self.assertEqual(result, "")
 
-            # Add messages that would normally be added
-            msgs.append(ChatMessage(role="assistant", content="Hello "))
-            msgs.append(ChatMessage(role="assistant", content="Hello World"))
+    def test_display_normal_real(self):
+        """display_normal renders reasoning then content and returns accumulated text."""
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=False, width=80)
+        printer = Printer(console=console)
+        printer.show_reasoning = True
 
-            return full_content, full_reasoning
+        def gen():
+            yield LLMResponse(reasoning="thinking process")
+            yield LLMResponse(content="final answer")
 
-        # Replace the method temporarily
-        original_display_normal = self.printer.display_normal
-        self.printer.display_normal = mock_display_normal
+        content, reasoning = printer.display_normal(gen())
+        self.assertIn("final answer", content)
+        self.assertIn("thinking process", reasoning)
+        out = buf.getvalue()
+        self.assertIn("Thinking:", out)
+        self.assertIn("final answer", out)
 
-        try:
-            # Call our simplified version
-            result_content, result_reasoning = self.printer.display_normal(None, messages)
+    def test_display_normal_skips_non_llmresponse(self):
+        """display_normal ignores non-LLMResponse items in the iterator."""
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=False, width=80)
+        printer = Printer(console=console)
 
-            # Verify results
-            self.assertEqual(result_content, "Hello World")
-            self.assertEqual(result_reasoning, "thinking")
-        finally:
-            # Restore original method
-            self.printer.display_normal = original_display_normal
+        def gen():
+            yield RefreshLive()
+            yield LLMResponse(content="answer")
+
+        content, _ = printer.display_normal(gen())
+        self.assertIn("answer", content)
+
+    def test_emit_reasoning_disabled(self):
+        """_emit_reasoning returns immediately when reasoning display is off."""
+        self.printer.show_reasoning = False
+        printed_len, header = self.printer._emit_reasoning("some reasoning", 0, False, flush=True)
+        self.assertEqual(printed_len, len("some reasoning"))
+        self.assertFalse(header)
+
+    def test_emit_reasoning_buffers_incomplete_line(self):
+        """Without flush and no newline, _emit_reasoning buffers and returns unchanged."""
+        self.printer.show_reasoning = True
+        printed_len, header = self.printer._emit_reasoning("partial line", 0, False, flush=False)
+        self.assertEqual(printed_len, 0)
+        self.assertFalse(header)
 
     @patch("yaicli.printer.Live")
-    def test_display_stream(self, mock_live):
-        """Test display_stream method with LLMContent."""
-        # Create mock messages list
-        messages = []
+    def test_display_stream_confirm_tool_call(self, mock_live):
+        """A ConfirmToolCall pauses the live, prompts, and resumes with the decision."""
+        mock_live.return_value = MagicMock()
+        printer = Printer()
+        printer.console = MagicMock()
+        printer.show_reasoning = True
 
-        # Setup mock Live instance
-        mock_live_instance = MagicMock()
-        mock_live.return_value = mock_live_instance
+        tc = ToolCall(id="c1", name="fn", arguments="{}")
+        received = []
 
-        # Create a simplified version of display_stream for testing
-        def mock_display_stream(iterator, msgs):
-            # Simulate what display_stream does without LLMContent dependency
-            self.printer._reset_state()
+        def gen():
+            decision = yield ConfirmToolCall(tool_call=tc)
+            received.append(decision)
+            yield LLMResponse(content="done")
 
-            # Start live display
-            live = mock_live_instance
-            live.start()
+        with patch.object(printer, "_confirm_tool_call", return_value=ToolConfirmDecision.ONCE):
+            printer.display_stream(gen())
 
-            # Process chunks and update display
-            full_content = "World"
-            full_reasoning = ""
+        self.assertEqual(received, [ToolConfirmDecision.ONCE])
 
-            # Update display
-            formatted_display = self.printer._format_display_text(full_content, full_reasoning)
-            live.update(formatted_display)
+    @patch("yaicli.printer.Live")
+    def test_display_stream_refresh_live_resets(self, mock_live):
+        """A RefreshLive flushes reasoning, restarts the live, and resets accumulators."""
+        mock_live.return_value = MagicMock()
+        printer = Printer()
+        printer.console = MagicMock()
+        printer.show_reasoning = True
 
-            # Add messages that would normally be added
-            msgs.append(ChatMessage(role="assistant", content="Hello "))
-            msgs.append(ChatMessage(role="assistant", content="World"))
+        def gen():
+            yield LLMResponse(reasoning="first thinking\n")
+            yield RefreshLive()
+            yield LLMResponse(content="second answer")
 
-            # Stop live display
-            live.stop()
+        content, _ = printer.display_stream(gen())
+        self.assertIn("second answer", content)
 
-            return full_content, full_reasoning
+    def test_emit_reasoning_flush_emits_partial_line(self):
+        """With flush, _emit_reasoning emits buffered text even without a trailing newline."""
+        self.printer.show_reasoning = True
+        self.printer.console = MagicMock()
+        printed_len, header = self.printer._emit_reasoning("partial no newline", 0, False, flush=True)
+        self.assertEqual(printed_len, len("partial no newline"))
+        self.assertTrue(header)
+        self.printer.console.print.assert_any_call("Thinking:")
 
-        # Replace the method temporarily
-        original_display_stream = self.printer.display_stream
-        self.printer.display_stream = mock_display_stream
+    @patch("yaicli.printer.Live")
+    def test_display_stream_propagates_error(self, mock_live):
+        """An error raised while processing a chunk stops the live and propagates."""
+        mock_live.return_value = MagicMock()
+        printer = Printer()
+        printer.console = MagicMock()
 
-        try:
-            # Call our simplified version
-            result_content, result_reasoning = self.printer.display_stream(None, messages)
+        def gen():
+            yield LLMResponse(content="x")
 
-            # Verify Live methods were called
-            mock_live_instance.start.assert_called()
-            mock_live_instance.update.assert_called()
-            mock_live_instance.stop.assert_called()
-
-            # Verify time.sleep was called
-            # We're not calling time.sleep in our mock implementation
-
-            # Verify messages were appended
-            self.assertEqual(len(messages), 2)
-        finally:
-            # Restore original method
-            self.printer.display_stream = original_display_stream
+        with patch.object(printer, "_process_chunk", side_effect=RuntimeError("boom")):
+            with self.assertRaises(RuntimeError):
+                printer.display_stream(gen())

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,25 @@
+"""Tests for yaicli.render: JustifyMarkdown default justify and plain_formatter."""
+
+from unittest.mock import patch
+
+from yaicli.render import JustifyMarkdown, plain_formatter
+
+
+def test_justify_markdown_uses_config_default():
+    """When no justify is passed, JustifyMarkdown falls back to the configured value."""
+    with patch("yaicli.render.cfg", {"JUSTIFY": "left"}):
+        md = JustifyMarkdown("# Title")
+    assert md.justify == "left"
+
+
+def test_justify_markdown_respects_explicit_justify():
+    """An explicit justify argument overrides the configured default."""
+    with patch("yaicli.render.cfg", {"JUSTIFY": "left"}):
+        md = JustifyMarkdown("# Title", justify="center")
+    assert md.justify == "center"
+
+
+def test_plain_formatter_returns_text_unchanged():
+    """plain_formatter returns its input verbatim, ignoring extra kwargs."""
+    assert plain_formatter("hello world") == "hello world"
+    assert plain_formatter("x", code_theme="monokai") == "x"

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1,0 +1,75 @@
+import json
+
+import pytest
+
+from yaicli.tools.approval import ToolApprovalManager
+
+
+def make_manager(tmp_path) -> ToolApprovalManager:
+    return ToolApprovalManager(permissions_path=tmp_path / "tool_permissions.json")
+
+
+def test_missing_file_is_empty(tmp_path):
+    mgr = make_manager(tmp_path)
+    assert mgr.persistent_allow == set()
+    assert mgr.is_allowed("anything") is False
+
+
+def test_malformed_file_treated_as_empty(tmp_path):
+    path = tmp_path / "tool_permissions.json"
+    path.write_text("not json{", encoding="utf-8")
+    mgr = ToolApprovalManager(permissions_path=path)
+    assert mgr.persistent_allow == set()
+    assert mgr.is_allowed("anything") is False
+
+
+def test_session_allow_is_not_persisted(tmp_path):
+    path = tmp_path / "tool_permissions.json"
+    mgr = ToolApprovalManager(permissions_path=path)
+    mgr.allow_session("get_weather")
+    assert mgr.is_allowed("get_weather") is True
+    # Session approval never touches the file
+    assert not path.exists()
+
+
+def test_persist_writes_and_reloads(tmp_path):
+    path = tmp_path / "tool_permissions.json"
+    mgr = ToolApprovalManager(permissions_path=path)
+    mgr.allow_persist("get_weather")
+
+    assert path.exists()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert "get_weather" in data["always_allow"]
+
+    # A fresh manager loaded from the same file honors the approval
+    reloaded = ToolApprovalManager(permissions_path=path)
+    assert reloaded.is_allowed("get_weather") is True
+
+
+def test_mcp_and_function_names_are_distinct(tmp_path):
+    mgr = make_manager(tmp_path)
+    mgr.allow_session("_mcp__read")
+    assert mgr.is_allowed("_mcp__read") is True
+    # A built-in function sharing the base name is a different approval
+    assert mgr.is_allowed("read") is False
+
+
+def test_atomic_write_failure_keeps_prior_file(tmp_path, monkeypatch):
+    path = tmp_path / "tool_permissions.json"
+    mgr = ToolApprovalManager(permissions_path=path)
+    mgr.allow_persist("first")  # file now contains "first"
+
+    def boom(*args, **kwargs):
+        raise OSError("simulated write failure")
+
+    monkeypatch.setattr("os.replace", boom)
+    with pytest.raises(OSError):
+        mgr.allow_persist("second")
+
+    # Prior file is intact and uncorrupted
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["always_allow"] == ["first"]
+    # In-memory allowlist unchanged on failure
+    assert "second" not in mgr.persistent_allow
+    # No leftover temp files
+    assert list(tmp_path.glob(".tool_permissions_*")) == []

--- a/tests/tools/test_fetch_webpage.py
+++ b/tests/tools/test_fetch_webpage.py
@@ -1,5 +1,7 @@
 """Test fetch_webpage function."""
 
+import httpx
+import pytest
 from unittest.mock import Mock, patch
 
 from yaicli.functions.buildin.fetch_webpage import Function
@@ -245,3 +247,98 @@ class TestFetchWebpage:
 
         assert result == "Extracted content"
         assert mock_trafilatura.fetch_url.call_count == 2
+
+
+class TestFetchWebpageCoverage:
+    """Cover remaining branches in fetch_webpage."""
+
+    def test_default_headers_with_referer(self):
+        headers = Function._get_default_headers(referer="http://ref.example")
+        assert headers["Referer"] == "http://ref.example"
+
+    def test_accept_language_explicit(self):
+        assert Function._get_accept_language("en-US") == "en-US"
+
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("http://site.cn", "zh-CN"),
+            ("http://site.jp", "ja-JP"),
+            ("http://site.kr", "ko-KR"),
+            ("http://site.de", "de-DE"),
+            ("http://site.fr", "fr-FR"),
+            ("http://site.es", "es-ES"),
+        ],
+    )
+    def test_accept_language_by_tld(self, url, expected):
+        assert expected in Function._get_accept_language("auto", url)
+
+    def test_accept_language_default_fallback(self):
+        assert "zh-CN" in Function._get_accept_language("auto", "http://site.io")
+
+    def _make_client(self, response=None, side_effect=None):
+        client = Mock()
+        if side_effect is not None:
+            client.get.side_effect = side_effect
+        else:
+            client.get.return_value = response
+        client.__enter__ = Mock(return_value=client)
+        client.__exit__ = Mock(return_value=False)
+        return client
+
+    @patch("yaicli.functions.buildin.fetch_webpage.time.sleep")
+    def test_httpx_redirect_status_exhausts(self, _sleep):
+        resp = Mock()
+        resp.status_code = 301
+        client = self._make_client(response=resp)
+        with patch("yaicli.functions.buildin.fetch_webpage.httpx.Client", return_value=client):
+            result = Function._fetch_with_httpx(
+                url="http://x", timeout=1, max_retries=2, verify_ssl=True, follow_redirects=True, headers={}
+            )
+        assert "Failed to fetch" in result
+
+    def test_httpx_non_200_returns_failed(self):
+        resp = Mock()
+        resp.status_code = 404
+        resp.reason_phrase = "Not Found"
+        client = self._make_client(response=resp)
+        with patch("yaicli.functions.buildin.fetch_webpage.httpx.Client", return_value=client):
+            result = Function._fetch_with_httpx(
+                url="http://x", timeout=1, max_retries=1, verify_ssl=True, follow_redirects=True, headers={}
+            )
+        assert "HTTP 404" in result
+
+    @patch("yaicli.functions.buildin.fetch_webpage.time.sleep")
+    def test_httpx_status_error_exhausts(self, _sleep):
+        client = self._make_client(side_effect=httpx.HTTPStatusError("err", request=Mock(), response=Mock()))
+        with patch("yaicli.functions.buildin.fetch_webpage.httpx.Client", return_value=client):
+            result = Function._fetch_with_httpx(
+                url="http://x", timeout=1, max_retries=2, verify_ssl=True, follow_redirects=True, headers={}
+            )
+        assert "Failed to fetch" in result
+
+    @patch("yaicli.functions.buildin.fetch_webpage.time.sleep")
+    def test_httpx_unexpected_error_exhausts(self, _sleep):
+        client = self._make_client(side_effect=ValueError("boom"))
+        with patch("yaicli.functions.buildin.fetch_webpage.httpx.Client", return_value=client):
+            result = Function._fetch_with_httpx(
+                url="http://x", timeout=1, max_retries=2, verify_ssl=True, follow_redirects=True, headers={}
+            )
+        assert "Failed to fetch" in result
+
+    @patch("builtins.__import__")
+    @patch("yaicli.functions.buildin.fetch_webpage.time.sleep")
+    def test_trafilatura_exception_exhausts(self, _sleep, mock_import):
+        mock_traf = Mock()
+        mock_traf.fetch_url.side_effect = ValueError("boom")
+
+        def import_side_effect(name, *args, **kwargs):
+            if name == "trafilatura":
+                return mock_traf
+            return __import__(name, *args, **kwargs)
+
+        mock_import.side_effect = import_side_effect
+        result = Function._fetch_with_trafilatura(
+            url="http://x", timeout=1, max_retries=2, verify_ssl=True, follow_redirects=True, headers={}
+        )
+        assert "Failed to extract content" in result

--- a/tests/tools/test_fs_file_operations.py
+++ b/tests/tools/test_fs_file_operations.py
@@ -314,3 +314,153 @@ class TestFSFileOperations:
 
         assert result_dict["success"] is False
         assert "Unknown operation" in result_dict["error"]
+
+
+class TestFSFileOpsCoverage:
+    """Cover error-handling branches in fs_file_operations."""
+
+    def test_execute_top_level_exception(self, tmp_path):
+        from unittest.mock import patch
+
+        with patch("yaicli.functions.buildin.fs_file_operations.Path", side_effect=RuntimeError("boom")):
+            result = Function.execute("exists", str(tmp_path / "x"))
+        assert "boom" in json.loads(result)["error"]
+
+    def test_create_directory_permission_error(self, tmp_path):
+        from unittest.mock import patch
+
+        target = tmp_path / "newdir"
+        with patch("pathlib.Path.mkdir", side_effect=PermissionError):
+            result = Function.execute("create_dir", str(target))
+        assert "Permission denied" in json.loads(result)["error"]
+
+    def test_create_directory_generic_error(self, tmp_path):
+        from unittest.mock import patch
+
+        target = tmp_path / "newdir"
+        with patch("pathlib.Path.mkdir", side_effect=OSError("disk full")):
+            result = Function.execute("create_dir", str(target))
+        assert "disk full" in json.loads(result)["error"]
+
+    def test_delete_neither_file_nor_dir(self, tmp_path):
+        import os
+        import sys
+
+        if sys.platform == "win32":
+            import pytest
+
+            pytest.skip("mkfifo unsupported")
+        fifo = tmp_path / "fifo"
+        os.mkfifo(str(fifo))
+        result = Function.execute("delete", str(fifo))
+        assert "neither a file nor a directory" in json.loads(result)["error"]
+
+    def test_delete_permission_error(self, tmp_path):
+        from unittest.mock import patch
+
+        f = tmp_path / "f.txt"
+        f.write_text("x")
+        with patch("pathlib.Path.unlink", side_effect=PermissionError):
+            result = Function.execute("delete", str(f))
+        assert "Permission denied" in json.loads(result)["error"]
+
+    def test_delete_generic_error(self, tmp_path):
+        from unittest.mock import patch
+
+        f = tmp_path / "f.txt"
+        f.write_text("x")
+        with patch("pathlib.Path.unlink", side_effect=OSError("busy")):
+            result = Function.execute("delete", str(f))
+        assert "busy" in json.loads(result)["error"]
+
+    def test_move_permission_error(self, tmp_path):
+        from unittest.mock import patch
+
+        src = tmp_path / "s.txt"
+        src.write_text("x")
+        with patch("yaicli.functions.buildin.fs_file_operations.shutil.move", side_effect=PermissionError):
+            result = Function.execute("move", str(src), str(tmp_path / "d.txt"))
+        assert "Permission denied" in json.loads(result)["error"]
+
+    def test_move_generic_error(self, tmp_path):
+        from unittest.mock import patch
+
+        src = tmp_path / "s.txt"
+        src.write_text("x")
+        with patch("yaicli.functions.buildin.fs_file_operations.shutil.move", side_effect=OSError("xdev")):
+            result = Function.execute("move", str(src), str(tmp_path / "d.txt"))
+        assert "xdev" in json.loads(result)["error"]
+
+    def test_copy_source_neither_file_nor_dir(self, tmp_path):
+        import os
+        import sys
+
+        if sys.platform == "win32":
+            import pytest
+
+            pytest.skip("mkfifo unsupported")
+        fifo = tmp_path / "fifo"
+        os.mkfifo(str(fifo))
+        result = Function.execute("copy", str(fifo), str(tmp_path / "d"))
+        assert "neither a file nor a directory" in json.loads(result)["error"]
+
+    def test_copy_permission_error(self, tmp_path):
+        from unittest.mock import patch
+
+        src = tmp_path / "s.txt"
+        src.write_text("x")
+        with patch("yaicli.functions.buildin.fs_file_operations.shutil.copy2", side_effect=PermissionError):
+            result = Function.execute("copy", str(src), str(tmp_path / "d.txt"))
+        assert "Permission denied" in json.loads(result)["error"]
+
+    def test_copy_generic_error(self, tmp_path):
+        from unittest.mock import patch
+
+        src = tmp_path / "s.txt"
+        src.write_text("x")
+        with patch("yaicli.functions.buildin.fs_file_operations.shutil.copy2", side_effect=OSError("nospace")):
+            result = Function.execute("copy", str(src), str(tmp_path / "d.txt"))
+        assert "nospace" in json.loads(result)["error"]
+
+    def test_exists_other_type(self, tmp_path):
+        import os
+        import sys
+
+        if sys.platform == "win32":
+            import pytest
+
+            pytest.skip("mkfifo unsupported")
+        fifo = tmp_path / "fifo"
+        os.mkfifo(str(fifo))
+        data = json.loads(Function.execute("exists", str(fifo)))
+        assert data["exists"] is True
+        assert data["type"] == "other"
+
+    def test_get_info_dir_iterdir_permission(self, tmp_path):
+        from unittest.mock import patch
+
+        d = tmp_path / "d"
+        d.mkdir()
+        with patch("pathlib.Path.iterdir", side_effect=PermissionError):
+            result = Function.execute("get_info", str(d))
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["info"]["item_count"] is None
+
+    def test_get_info_permission_error(self):
+        from unittest.mock import MagicMock
+
+        mock_path = MagicMock()
+        mock_path.exists.return_value = True
+        mock_path.stat.side_effect = PermissionError
+        result = Function._get_info(mock_path)
+        assert "Permission denied" in json.loads(result)["error"]
+
+    def test_get_info_generic_error(self):
+        from unittest.mock import MagicMock
+
+        mock_path = MagicMock()
+        mock_path.exists.return_value = True
+        mock_path.stat.side_effect = OSError("io")
+        result = Function._get_info(mock_path)
+        assert "io" in json.loads(result)["error"]

--- a/tests/tools/test_tools_init.py
+++ b/tests/tools/test_tools_init.py
@@ -1,0 +1,233 @@
+"""Tests for yaicli.tools package: name parsing, lazy MCP imports, mcp tool schemas, and execute_tool_call."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rich.panel import Panel
+
+from yaicli.exceptions import MCPToolsError
+from yaicli.schemas import ToolCall
+from yaicli.tools import (
+    execute_tool_call,
+    get_anthropic_mcp_tools,
+    get_anthropic_schemas,
+    get_mcp,
+    get_mcp_manager,
+    get_openai_mcp_tools,
+    get_openai_schemas,
+    parse_mcp_tool_name,
+)
+
+FAKE_CFG = {"SHOW_FUNCTION_OUTPUT": False, "SHOW_MCP_OUTPUT": False}
+
+
+class TestParseMcpToolName:
+    def test_strips_prefix(self):
+        assert parse_mcp_tool_name("_mcp__clock") == "clock"
+
+    def test_no_prefix_unchanged(self):
+        assert parse_mcp_tool_name("plain") == "plain"
+
+
+class TestLazyMcpImports:
+    def test_get_mcp_manager_lazy(self):
+        """get_mcp_manager lazily delegates to yaicli.tools.mcp.get_mcp_manager."""
+        fake_mgr = MagicMock()
+        with patch("yaicli.tools.mcp.get_mcp_manager", return_value=fake_mgr) as m:
+            result = get_mcp_manager()
+        assert result is fake_mgr
+        m.assert_called_once()
+
+    def test_get_mcp_lazy(self):
+        """get_mcp lazily delegates to yaicli.tools.mcp.get_mcp."""
+        fake_tool = MagicMock()
+        with patch("yaicli.tools.mcp.get_mcp", return_value=fake_tool) as m:
+            result = get_mcp("clock")
+        assert result is fake_tool
+        m.assert_called_once_with("clock")
+
+
+class TestMcpToolSchemas:
+    def test_openai_mcp_tools_success(self):
+        mgr = MagicMock()
+        mgr.to_openai_tools.return_value = [{"type": "function"}]
+        with patch("yaicli.tools.get_mcp_manager", return_value=mgr):
+            assert get_openai_mcp_tools() == [{"type": "function"}]
+
+    def test_openai_mcp_tools_error_wrapped(self):
+        with patch("yaicli.tools.get_mcp_manager", side_effect=RuntimeError("boom")):
+            with pytest.raises(MCPToolsError, match="Error getting MCP tools"):
+                get_openai_mcp_tools()
+
+    def test_anthropic_mcp_tools_success(self):
+        mgr = MagicMock()
+        mgr.to_anthropic_tools.return_value = [{"name": "x"}]
+        with patch("yaicli.tools.get_mcp_manager", return_value=mgr):
+            assert get_anthropic_mcp_tools() == [{"name": "x"}]
+
+    def test_anthropic_mcp_tools_error_wrapped(self):
+        with patch("yaicli.tools.get_mcp_manager", side_effect=RuntimeError("boom")):
+            with pytest.raises(MCPToolsError, match="Error getting MCP tools for Anthropic"):
+                get_anthropic_mcp_tools()
+
+
+class TestExecuteToolCall:
+    def test_function_call_success(self):
+        tool = MagicMock()
+        tool.execute.return_value = "result text"
+        console = MagicMock()
+        tc = ToolCall(id="1", name="get_weather", arguments='{"city": "NYC"}')
+        with (
+            patch("yaicli.tools.cfg", FAKE_CFG),
+            patch("yaicli.tools.get_function", return_value=tool),
+            patch("yaicli.tools.console", console),
+        ):
+            result, ok = execute_tool_call(tc)
+
+        assert ok is True
+        assert result == "result text"
+        tool.execute.assert_called_once_with(city="NYC")
+        printed = [str(c.args[0]) for c in console.print.call_args_list]
+        assert any("@Function call: get_weather" in t for t in printed)
+
+    def test_function_call_show_output_panel(self):
+        tool = MagicMock()
+        tool.execute.return_value = "result text"
+        console = MagicMock()
+        tc = ToolCall(id="1", name="get_weather", arguments='{"city": "NYC"}')
+        with (
+            patch("yaicli.tools.cfg", {"SHOW_FUNCTION_OUTPUT": True, "SHOW_MCP_OUTPUT": False}),
+            patch("yaicli.tools.get_function", return_value=tool),
+            patch("yaicli.tools.console", console),
+        ):
+            result, ok = execute_tool_call(tc)
+
+        assert ok is True
+        assert any(isinstance(c.args[0], Panel) for c in console.print.call_args_list)
+
+    def test_mcp_call_success_strips_prefix(self):
+        tool = MagicMock()
+        tool.execute.return_value = "mcp result"
+        console = MagicMock()
+        tc = ToolCall(id="1", name="_mcp__clock", arguments="{}")
+        with (
+            patch("yaicli.tools.cfg", FAKE_CFG),
+            patch("yaicli.tools.get_mcp", return_value=tool),
+            patch("yaicli.tools.console", console),
+        ):
+            result, ok = execute_tool_call(tc)
+
+        assert ok is True
+        assert result == "mcp result"
+        printed = [str(c.args[0]) for c in console.print.call_args_list]
+        assert any("@Mcp call: clock" in t for t in printed)
+
+    def test_tool_not_found(self):
+        console = MagicMock()
+        tc = ToolCall(id="1", name="missing", arguments="{}")
+        with (
+            patch("yaicli.tools.cfg", FAKE_CFG),
+            patch("yaicli.tools.get_function", side_effect=ValueError("nope")),
+            patch("yaicli.tools.console", console),
+        ):
+            result, ok = execute_tool_call(tc)
+
+        assert ok is False
+        assert "not exists" in result
+
+    def test_invalid_arguments_not_dict(self):
+        tool = MagicMock()
+        console = MagicMock()
+        tc = ToolCall(id="1", name="fn", arguments='"just a string"')
+        with (
+            patch("yaicli.tools.cfg", FAKE_CFG),
+            patch("yaicli.tools.get_function", return_value=tool),
+            patch("yaicli.tools.console", console),
+        ):
+            result, ok = execute_tool_call(tc)
+
+        assert ok is False
+        assert "should be JSON object" in result
+        tool.execute.assert_not_called()
+
+    def test_arguments_parse_error(self):
+        tool = MagicMock()
+        console = MagicMock()
+        tc = ToolCall(id="1", name="fn", arguments="{}")
+        with (
+            patch("yaicli.tools.cfg", FAKE_CFG),
+            patch("yaicli.tools.get_function", return_value=tool),
+            patch("yaicli.tools.console", console),
+            patch("yaicli.tools.repair_json", side_effect=ValueError("bad")),
+        ):
+            result, ok = execute_tool_call(tc)
+
+        assert ok is False
+        assert "Invalid arguments from llm" in result
+
+    def test_execute_raises(self):
+        tool = MagicMock()
+        tool.execute.side_effect = RuntimeError("exec failed")
+        console = MagicMock()
+        tc = ToolCall(id="1", name="fn", arguments='{"a": 1}')
+        with (
+            patch("yaicli.tools.cfg", FAKE_CFG),
+            patch("yaicli.tools.get_function", return_value=tool),
+            patch("yaicli.tools.console", console),
+        ):
+            result, ok = execute_tool_call(tc)
+
+        assert ok is False
+        assert "Call function error" in result
+
+    def test_announce_false_suppresses_call_line(self):
+        tool = MagicMock()
+        tool.execute.return_value = "r"
+        console = MagicMock()
+        tc = ToolCall(id="1", name="fn", arguments="{}")
+        with (
+            patch("yaicli.tools.cfg", FAKE_CFG),
+            patch("yaicli.tools.get_function", return_value=tool),
+            patch("yaicli.tools.console", console),
+        ):
+            result, ok = execute_tool_call(tc, announce=False)
+
+        assert ok is True
+        printed = [str(c.args[0]) for c in console.print.call_args_list]
+        assert not any("call:" in t for t in printed)
+
+
+class TestSchemas:
+    """Tests for get_openai_schemas / get_anthropic_schemas transform + cache."""
+
+    def test_get_openai_schemas_builds_and_caches(self):
+        func = MagicMock()
+        func.func_cls.openai_schema = {"name": "fn", "parameters": {}}
+        with (
+            patch("yaicli.tools._openai_schemas_cache", None),
+            patch("yaicli.tools.list_functions", return_value=[func]),
+        ):
+            schemas = get_openai_schemas()
+
+        assert schemas == [{"type": "function", "function": {"name": "fn", "parameters": {}}}]
+
+    def test_get_openai_schemas_returns_cache(self):
+        cached = [{"type": "function", "function": {"name": "cached"}}]
+        with patch("yaicli.tools._openai_schemas_cache", cached):
+            assert get_openai_schemas() is cached
+
+    def test_get_anthropic_schemas_builds(self):
+        func = MagicMock()
+        func.func_cls.anthropic_schema = {"name": "fn"}
+        with (
+            patch("yaicli.tools._anthropic_schemas_cache", None),
+            patch("yaicli.tools.list_functions", return_value=[func]),
+        ):
+            schemas = get_anthropic_schemas()
+
+        assert schemas == [{"name": "fn"}]
+
+    def test_get_anthropic_schemas_returns_cache(self):
+        cached = [{"name": "cached"}]
+        with patch("yaicli.tools._anthropic_schemas_cache", cached):
+            assert get_anthropic_schemas() is cached

--- a/yaicli/cli.py
+++ b/yaicli/cli.py
@@ -46,6 +46,7 @@ from .llms import LLMClient
 from .printer import Printer
 from .role import Role, RoleManager, role_mgr
 from .schemas import ChatMessage, ImageData, ToolPolicy
+from .tools.approval import ToolApprovalManager
 from .utils import detect_os, detect_shell, filter_command
 
 
@@ -555,7 +556,13 @@ class CLI:
     def _create_client(self):
         """Create an LLM client instance based on configuration"""
         try:
-            return LLMClient(provider_name=cfg["PROVIDER"].lower(), verbose=self.verbose, config=cfg)
+            return LLMClient(
+                provider_name=cfg["PROVIDER"].lower(),
+                verbose=self.verbose,
+                config=cfg,
+                approval=ToolApprovalManager(),
+                interactive=sys.stdin.isatty(),
+            )
         except YaicliError as e:
             self.console.print(f"Error creating client: {e}", style="red")
             raise typer.Abort()

--- a/yaicli/const.py
+++ b/yaicli/const.py
@@ -46,6 +46,7 @@ CONFIG_PATH = Path("~/.config/yaicli/config.ini").expanduser()
 ROLES_DIR = CONFIG_PATH.parent / "roles"
 FUNCTIONS_DIR = CONFIG_PATH.parent / "functions"
 MCP_JSON_PATH = CONFIG_PATH.parent / "mcp.json"
+TOOL_PERMISSIONS_PATH = CONFIG_PATH.parent / "tool_permissions.json"
 
 # Default configuration values
 DEFAULT_CODE_THEME = "monokai"
@@ -78,6 +79,7 @@ DEFAULT_REASONING_EFFORT: Optional[Literal["low", "high", "medium", "default", "
 DEFAULT_ENABLE_MCP: BOOL_STR = "false"
 DEFAULT_SHOW_MCP_OUTPUT: BOOL_STR = "false"
 DEFAULT_MAX_TOOL_CALL_DEPTH: int = 8
+DEFAULT_TOOL_CONFIRM: BOOL_STR = "true"
 DEFAULT_EXCLUDE_PARAMS: str = ""  # Empty by default
 
 # Providers known to not support vision/image input
@@ -169,6 +171,7 @@ DEFAULT_CONFIG_MAP = {
     "ENABLE_MCP": {"value": DEFAULT_ENABLE_MCP, "env_key": "YAI_ENABLE_MCP", "type": bool},
     "SHOW_MCP_OUTPUT": {"value": DEFAULT_SHOW_MCP_OUTPUT, "env_key": "YAI_SHOW_MCP_OUTPUT", "type": bool},
     "MAX_TOOL_CALL_DEPTH": {"value": DEFAULT_MAX_TOOL_CALL_DEPTH, "env_key": "YAI_MAX_TOOL_CALL_DEPTH", "type": int},
+    "TOOL_CONFIRM": {"value": DEFAULT_TOOL_CONFIRM, "env_key": "YAI_TOOL_CONFIRM", "type": bool},
     "EXCLUDE_PARAMS": {"value": DEFAULT_EXCLUDE_PARAMS, "env_key": "YAI_EXCLUDE_PARAMS", "type": str},
     # MiniMax specific settings
     "MINIMAX_REASONING_SPLIT": {
@@ -239,6 +242,11 @@ SHOW_MCP_OUTPUT={DEFAULT_CONFIG_MAP["SHOW_MCP_OUTPUT"]["value"]}
 
 # Maximum number of tool calls to make in a single request
 MAX_TOOL_CALL_DEPTH={DEFAULT_CONFIG_MAP["MAX_TOOL_CALL_DEPTH"]["value"]}
+
+# Ask for confirmation before executing each tool/function call.
+# Set to false to execute tool calls silently (previous behavior).
+# Tools permanently allowed are stored in tool_permissions.json next to this file.
+TOOL_CONFIRM={DEFAULT_CONFIG_MAP["TOOL_CONFIRM"]["value"]}
 
 # Comma-separated list of API parameters to exclude from requests
 # Example: temperature,top_p,frequency_penalty

--- a/yaicli/llms/client.py
+++ b/yaicli/llms/client.py
@@ -2,8 +2,9 @@ from typing import Generator, List, Optional, Union
 
 from ..config import cfg
 from ..console import get_console
-from ..schemas import ChatMessage, LLMResponse, RefreshLive, ToolCall, ToolPolicy
+from ..schemas import ChatMessage, ConfirmToolCall, LLMResponse, RefreshLive, ToolCall, ToolConfirmDecision, ToolPolicy
 from ..tools import execute_tool_call
+from ..tools.approval import ToolApprovalManager
 from ..tools.mcp import MCP_TOOL_NAME_PREFIX
 from .provider import ProviderFactory
 
@@ -18,13 +19,25 @@ class LLMClient:
     3. Handling conversation flow with tools
     """
 
-    __slots__ = ("config", "verbose", "console", "enable_function", "enable_mcp", "max_tool_call_depth", "provider")
+    __slots__ = (
+        "config",
+        "verbose",
+        "console",
+        "enable_function",
+        "enable_mcp",
+        "max_tool_call_depth",
+        "provider",
+        "approval",
+        "interactive",
+    )
 
     def __init__(
         self,
         provider_name: str,
         config: dict = cfg,
         verbose: bool = False,
+        approval: Optional[ToolApprovalManager] = None,
+        interactive: bool = True,
         **kwargs,
     ):
         """
@@ -34,12 +47,16 @@ class LLMClient:
             provider_name: Name of the provider to use, default to openai if not known
             config: Configuration dictionary
             verbose: Whether to enable verbose logging
+            approval: Tool approval manager (created if not provided)
+            interactive: Whether the session can prompt the user (TTY available)
         """
         self.config = config
         self.verbose = verbose
         self.console = get_console()
         self.enable_function = self.config["ENABLE_FUNCTIONS"]
         self.enable_mcp = self.config["ENABLE_MCP"]
+        self.approval = approval or ToolApprovalManager()
+        self.interactive = interactive
 
         # Use provided provider or create one
         if provider_name not in ProviderFactory.providers_map:
@@ -55,7 +72,7 @@ class LLMClient:
         stream: bool = False,
         recursion_depth: int = 0,
         tool_policy: Optional[ToolPolicy] = None,
-    ) -> Generator[Union[LLMResponse, RefreshLive], None, None]:
+    ) -> Generator[Union[LLMResponse, RefreshLive, ConfirmToolCall], Optional[ToolConfirmDecision], None]:
         """
         Get completion from provider with tool calling support
 
@@ -143,8 +160,13 @@ class LLMClient:
         stream: bool,
         recursion_depth: int,
         tool_policy: ToolPolicy,
-    ) -> Generator[Union[LLMResponse, RefreshLive], None, None]:
-        """Execute tool calls and continue the conversation"""
+    ) -> Generator[Union[LLMResponse, RefreshLive, ConfirmToolCall], Optional[ToolConfirmDecision], None]:
+        """Execute tool calls and continue the conversation.
+
+        Each tool call passes through the execution-confirmation gate before it runs
+        (unless TOOL_CONFIRM is disabled or the tool is already approved). Denied calls
+        still receive a matching tool result so the provider request stays valid.
+        """
         # Signal that new content is coming
         yield RefreshLive()
 
@@ -152,9 +174,55 @@ class LLMClient:
 
         # Execute each tool call and add results to messages
         tool_role = self.provider.detect_tool_role()
+        confirm_enabled = self.config["TOOL_CONFIRM"]
 
         for tool_call in tool_calls:
-            function_result, _ = execute_tool_call(tool_call)
+            # Capture the gate-time name: MCP names keep the _mcp__ prefix here,
+            # but execute_tool_call strips it in place at execution time.
+            gate_name = tool_call.name
+            decision = ToolConfirmDecision.ONCE
+            prompted = False
+
+            if confirm_enabled and not self.approval.is_allowed(gate_name):
+                if not self.interactive:
+                    # No TTY to prompt on: deny and tell the user how to proceed.
+                    self.console.print(
+                        f"Tool '{gate_name}' requires confirmation but the session is non-interactive; denying. "
+                        f"Pre-approve it in {self.approval.permissions_path} or set TOOL_CONFIRM=false.",
+                        style="yellow",
+                    )
+                    decision = ToolConfirmDecision.DENY
+                else:
+                    decision = (yield ConfirmToolCall(tool_call)) or ToolConfirmDecision.DENY
+                    prompted = True
+                    if decision == ToolConfirmDecision.SESSION:
+                        self.approval.allow_session(gate_name)
+                    elif decision == ToolConfirmDecision.PERSIST:
+                        try:
+                            self.approval.allow_persist(gate_name)
+                        except OSError:
+                            # Persisting failed (e.g., disk/permission); keep it for the session.
+                            self.approval.allow_session(gate_name)
+                            self.console.print(
+                                f"Could not persist approval for '{gate_name}'; allowed for this session only.",
+                                style="yellow",
+                            )
+
+            if decision == ToolConfirmDecision.DENY:
+                messages.append(
+                    ChatMessage(
+                        role=tool_role,
+                        content="The user declined to execute this tool.",
+                        # De-prefix MCP names to match the executed path (execute_tool_call
+                        # strips the prefix), so the result name is consistent either way.
+                        name=gate_name.removeprefix(MCP_TOOL_NAME_PREFIX),
+                        tool_call_id=tool_call.id,
+                    )
+                )
+                continue
+
+            # Avoid double-printing the call: the prompt already showed it when we prompted.
+            function_result, _ = execute_tool_call(tool_call, announce=not prompted)
 
             messages.append(
                 ChatMessage(

--- a/yaicli/llms/providers/cohere_provider.py
+++ b/yaicli/llms/providers/cohere_provider.py
@@ -304,6 +304,9 @@ class CohereBadrockProvider(CohereProvider):
 
     def create_client(self):
         """Create Bedrock client with AWS credentials"""
+        # Bedrock/Sagemaker authenticate via AWS credentials; the Cohere ``api_key`` added
+        # by the base __init__ is not a valid argument for these clients, so drop it.
+        self.client_params.pop("api_key", None)
         for k, p in self.CLIENT_KEYS:
             v = self.config.get(k, None)
             if v is None:

--- a/yaicli/printer.py
+++ b/yaicli/printer.py
@@ -1,13 +1,15 @@
 from dataclasses import dataclass, field
-from typing import Iterator, List, Tuple, Union
+from typing import Generator, Iterator, List, Optional, Tuple, Union
 
 from rich.console import Group, RenderableType
 from rich.live import Live
+from rich.panel import Panel
+from rich.prompt import Prompt
 
 from .config import Config, get_config
 from .console import YaiConsole, get_console
 from .render import Markdown, plain_formatter
-from .schemas import LLMResponse, RefreshLive
+from .schemas import ConfirmToolCall, LLMResponse, RefreshLive, ToolConfirmDecision
 
 
 @dataclass
@@ -169,8 +171,14 @@ class Printer:
         return full_content, full_reasoning
 
     def _create_and_start_live(self) -> Live:
-        """Create and start a new Live instance."""
-        live = Live(console=self.console)
+        """Create and start a new Live instance.
+
+        auto_refresh is disabled so all drawing happens synchronously on the main
+        thread (via explicit refresh on each update). This avoids the background
+        refresh thread racing with direct console prints (e.g., large tool-output
+        panels), which otherwise leaves duplicated/misaligned frames behind.
+        """
+        live = Live(console=self.console, auto_refresh=False)
         live.start()
         return live
 
@@ -179,21 +187,126 @@ class Printer:
         if live.is_started:
             live.stop()
 
-    def display_stream(self, stream_iterator: Iterator[Union["LLMResponse", RefreshLive]]) -> tuple[str, str]:
-        """Process and display LLMContent stream, including reasoning and content parts."""
+    def _confirm_tool_call(self, tool_call) -> ToolConfirmDecision:
+        """Prompt the user to confirm a pending tool call.
+
+        Returns a ToolConfirmDecision. Interruptions (Ctrl-C / EOF) are treated as deny
+        so they never propagate as an unhandled error through the stream pump.
+        """
+        self.console.print(
+            Panel(
+                f"{tool_call.name}({tool_call.arguments})",
+                title="Confirm tool call",
+                title_align="left",
+                border_style="bold magenta",
+                expand=False,
+            )
+        )
+        choice_map = {
+            "y": ToolConfirmDecision.ONCE,
+            "a": ToolConfirmDecision.SESSION,
+            "A": ToolConfirmDecision.PERSIST,
+            "n": ToolConfirmDecision.DENY,
+        }
+        try:
+            choice = Prompt.ask(
+                r"Execute tool? \[y]once, \[a]session, \[A]always, \[n]o",
+                choices=list(choice_map.keys()),
+                default="y",
+                case_sensitive=True,
+                show_choices=False,
+                console=self.console,
+            )
+        except (KeyboardInterrupt, EOFError):
+            self.console.print("\nTool call denied.", style="yellow")
+            return ToolConfirmDecision.DENY
+        return choice_map[choice]
+
+    def _emit_reasoning(
+        self, full_reasoning: str, printed_len: int, header_shown: bool, *, flush: bool
+    ) -> Tuple[int, bool]:
+        """Stream newly-arrived reasoning as append-only text.
+
+        Reasoning is printed rather than re-rendered in the live region, so a tall
+        reasoning block never sits in a live that cannot be overwritten cleanly when it
+        overflows the screen. Without ``flush`` only whole lines are emitted; the partial
+        trailing line is buffered until its newline (or a flush) arrives.
+
+        Returns the updated (printed_len, header_shown).
+        """
+        if not self.show_reasoning:
+            return len(full_reasoning), header_shown
+        pending = full_reasoning[printed_len:]
+        if not pending:
+            return printed_len, header_shown
+        if flush:
+            emitted = len(pending)
+        else:
+            nl = pending.rfind("\n")
+            if nl == -1:
+                return printed_len, header_shown  # no complete line yet; keep buffering
+            pending = pending[: nl + 1]
+            emitted = len(pending)
+        text = pending.strip("\n")
+        if text:
+            if not header_shown:
+                self.console.print("Thinking:")
+                header_shown = True
+            prefixed = self._REASONING_PREFIX + text.replace("\n", f"\n{self._REASONING_PREFIX}")
+            # markup/highlight off: reasoning is arbitrary model text, not Rich markup.
+            self.console.print(prefixed, style="dim", markup=False, highlight=False)
+        return printed_len + emitted, header_shown
+
+    def display_stream(
+        self,
+        stream_iterator: Generator[
+            Union["LLMResponse", RefreshLive, ConfirmToolCall], Optional[ToolConfirmDecision], None
+        ],
+    ) -> tuple[str, str]:
+        """Process and display an LLM stream.
+
+        Reasoning is streamed as append-only text; only the content is rendered in the
+        live region. Driven with next()/send() so a ConfirmToolCall signal can pause the
+        live, prompt the user, and resume the generator with the user's decision.
+        """
         self._reset_state()
         full_content = full_reasoning = ""
+        printed_reasoning = 0
+        reasoning_header_shown = False
         live = self._create_and_start_live()
+        send_value: Optional[ToolConfirmDecision] = None
 
         try:
-            for chunk in stream_iterator:
+            while True:
+                try:
+                    if send_value is None:
+                        chunk = next(stream_iterator)
+                    else:
+                        chunk = stream_iterator.send(send_value)
+                        send_value = None
+                except StopIteration:
+                    break
+
+                if isinstance(chunk, ConfirmToolCall):
+                    # Pause the live region so the prompt does not fight its refresh.
+                    self._safe_stop_live(live)
+                    send_value = self._confirm_tool_call(chunk.tool_call)
+                    # Fresh live for subsequent tool output / streaming.
+                    live = self._create_and_start_live()
+                    continue
+
                 if isinstance(chunk, RefreshLive):
-                    # Gracefully transition to new live session
+                    # Flush buffered reasoning, then transition to a new live session.
+                    printed_reasoning, reasoning_header_shown = self._emit_reasoning(
+                        full_reasoning, printed_reasoning, reasoning_header_shown, flush=True
+                    )
                     self._safe_stop_live(live)
                     live = self._create_and_start_live()
 
                     # Reset state for next completion
                     full_content = full_reasoning = ""
+                    printed_reasoning = 0
+                    reasoning_header_shown = False
                     self._reset_state()
                     continue
 
@@ -202,14 +315,25 @@ class Printer:
                     chunk.content or "", chunk.reasoning or "", full_content, full_reasoning
                 )
 
-                # Update display
-                formatted_display = self._format_display_text(full_content, full_reasoning)
-                live.update(formatted_display)
+                if full_content:
+                    # Content has started: flush any remaining reasoning above it, then
+                    # render the content in the live region.
+                    printed_reasoning, reasoning_header_shown = self._emit_reasoning(
+                        full_reasoning, printed_reasoning, reasoning_header_shown, flush=True
+                    )
+                    live.update(self._format_display_text(full_content, ""), refresh=True)
+                else:
+                    # Reasoning only so far: stream it append-only (whole lines).
+                    printed_reasoning, reasoning_header_shown = self._emit_reasoning(
+                        full_reasoning, printed_reasoning, reasoning_header_shown, flush=False
+                    )
 
         except Exception as e:
             self._safe_stop_live(live)
             raise e from None
         finally:
+            # Flush any trailing reasoning that never received a newline.
+            self._emit_reasoning(full_reasoning, printed_reasoning, reasoning_header_shown, flush=True)
             self._safe_stop_live(live)
 
         return full_content, full_reasoning

--- a/yaicli/schemas.py
+++ b/yaicli/schemas.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 from typing import List, Optional
 
+from .const import StrEnum
+
 
 @dataclass
 class ImageData:
@@ -57,3 +59,24 @@ class RefreshLive:
 
 class StopLive:
     """Stop live display"""
+
+
+@dataclass
+class ConfirmToolCall:
+    """Control signal: ask the user to confirm a tool call before execution.
+
+    Yielded out of the tool-execution loop so the display layer can pause the
+    live region, prompt the user, and resume the generator with a
+    ToolConfirmDecision via ``generator.send(...)``.
+    """
+
+    tool_call: ToolCall
+
+
+class ToolConfirmDecision(StrEnum):  # type: ignore
+    """User decision for a pending tool call confirmation."""
+
+    ONCE = "once"  # Execute this call only
+    SESSION = "session"  # Execute and stop asking for this tool this session
+    PERSIST = "persist"  # Execute and persist approval across runs
+    DENY = "deny"  # Do not execute; return a refusal result to the model

--- a/yaicli/tools/__init__.py
+++ b/yaicli/tools/__init__.py
@@ -107,11 +107,13 @@ def get_anthropic_mcp_tools() -> list[dict[str, Any]]:
         raise MCPToolsError(f"Error getting MCP tools for Anthropic: {e}") from e
 
 
-def execute_tool_call(tool_call: ToolCall) -> Tuple[str, bool]:
+def execute_tool_call(tool_call: ToolCall, announce: bool = True) -> Tuple[str, bool]:
     """Execute a tool call and return the result
 
     Args:
         tool_call: The tool call to execute
+        announce: Whether to print the "@... call" line. Set False when the call was
+            already shown to the user (e.g., by a confirmation prompt) to avoid duplication.
 
     Returns:
         Tuple[str, bool]: (result text, success flag)
@@ -127,7 +129,8 @@ def execute_tool_call(tool_call: ToolCall) -> Tuple[str, bool]:
         show_output = cfg["SHOW_MCP_OUTPUT"]
         _type = "mcp"
 
-    console.print(f"@{_type.title()} call: {tool_call.name}({tool_call.arguments})", style="blue")
+    if announce:
+        console.print(f"@{_type.title()} call: {tool_call.name}({tool_call.arguments})", style="blue")
     # 1. Get the tool
     try:
         tool = get_tool_func(tool_call.name)

--- a/yaicli/tools/approval.py
+++ b/yaicli/tools/approval.py
@@ -1,0 +1,83 @@
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Optional, Set
+
+from ..const import TOOL_PERMISSIONS_PATH
+
+# Key in the permissions JSON file holding the persistent allowlist
+_ALLOWLIST_KEY = "always_allow"
+
+
+class ToolApprovalManager:
+    """Track which tools the user has approved for execution.
+
+    Two scopes:
+    - ``session_allow``: in-memory, lives for the current process only.
+    - ``persistent_allow``: loaded from and written to a JSON file, survives restarts.
+
+    Tool names are keyed exactly as observed at the confirmation gate; MCP tool
+    names keep their ``_mcp__`` prefix so an MCP tool and a built-in function
+    sharing a base name are tracked as distinct approvals.
+    """
+
+    def __init__(self, permissions_path: Optional[Path] = None):
+        self.permissions_path: Path = permissions_path or TOOL_PERMISSIONS_PATH
+        self.session_allow: Set[str] = set()
+        self.persistent_allow: Set[str] = self._load()
+
+    def _load(self) -> Set[str]:
+        """Load the persistent allowlist, tolerating a missing or malformed file."""
+        try:
+            data = json.loads(self.permissions_path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, ValueError, OSError):
+            return set()
+        if not isinstance(data, dict):
+            return set()
+        names = data.get(_ALLOWLIST_KEY, [])
+        if not isinstance(names, list):
+            return set()
+        return {str(n) for n in names}
+
+    def is_allowed(self, name: str) -> bool:
+        """Return True if the tool is approved for the session or persistently."""
+        return name in self.session_allow or name in self.persistent_allow
+
+    def allow_session(self, name: str) -> None:
+        """Approve a tool for the remainder of this process."""
+        self.session_allow.add(name)
+
+    def allow_persist(self, name: str) -> None:
+        """Approve a tool and persist it across runs.
+
+        The file is written before the in-memory set is updated, so a failed write
+        leaves both the file and the in-memory allowlist unchanged.
+        """
+        updated = set(self.persistent_allow)
+        updated.add(name)
+        self._save(updated)
+        self.persistent_allow = updated
+
+    def _save(self, allowlist: Set[str]) -> None:
+        """Write the persistent allowlist atomically (temp file + rename).
+
+        A partial write cannot corrupt the existing file: content is written to a
+        temp file in the same directory and then atomically moved into place.
+        """
+        self.permissions_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps({_ALLOWLIST_KEY: sorted(allowlist)}, indent=2, ensure_ascii=False)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(self.permissions_path.parent), prefix=".tool_permissions_", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(payload)
+            os.replace(tmp_path, self.permissions_path)
+        except Exception:
+            # Clean up the temp file on failure; leave the existing file intact.
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise


### PR DESCRIPTION
## Summary

Adds a confirmation gate before each tool/function call, similar to Claude Code. When the model wants to run a tool, the user is prompted with four outcomes:

- **[y] once** — execute this call only
- **[a] session** — execute and stop asking for this tool for the rest of the process
- **[A] always** — execute and persist approval across runs
- **[n] deny** — refuse; a matched tool result is returned to the model so the conversation continues

Approvals are keyed by tool name (MCP names keep their `_mcp__` prefix, so an MCP tool and a same-named built-in are distinct). Permanent approvals persist to `~/.config/yaicli/tool_permissions.json` via an atomic write. The gate sits at the single execution chokepoint (`_execute_tools_and_continue` → `execute_tool_call`), so it is provider-agnostic.

Non-interactive sessions (piped stdin / no TTY) never block: allowlisted tools run, others are denied with a hint.

The prompt is delivered via a `ConfirmToolCall` signal yielded out of the stream generator; the printer pauses the live region, prompts, and resumes via `generator.send(decision)`.

## BREAKING CHANGE

Tool calls now require confirmation by default. Set `TOOL_CONFIRM=false` (env `YAI_TOOL_CONFIRM=false`) to restore the previous silent execution.

## Other changes in this branch

- **fix:** Cohere Bedrock/Sagemaker clients no longer receive the Cohere `api_key` (invalid arg for AWS-authenticated clients).
- **render fix:** reasoning is streamed as append-only text instead of being re-rendered in the live region, fixing duplicated `Thinking:` frames after large tool output.
- **tests:** broad coverage expansion across providers, CLI, context, and tools.

## Testing

- New: `tests/llms/test_tool_confirmation.py`, `tests/tools/test_approval.py`, and a reasoning-streaming regression in `tests/test_printer.py`.
- Full suite green (`uv run pytest`), ruff clean.

## Design / spec

Full artifacts archived under `openspec/changes/archive/2026-06-14-add-tool-confirmation/`; capability spec at `openspec/specs/tool-execution-confirmation/spec.md`.